### PR TITLE
Fix unused load_flow logic

### DIFF
--- a/src/recorder.rb
+++ b/src/recorder.rb
@@ -139,7 +139,7 @@ class TraceRecord
   end
 
   def load_flow(path, line, binding)
-    if @exprs.key?(path)
+    unless @exprs.key?(path)
       @exprs[path] = load_exprs(path)
     end
     path_exprs = @exprs[path]
@@ -238,10 +238,9 @@ class TraceRecord
     variable_id
   end
 
-  def load_exprs()
+  def load_exprs(path)
     # TODO: eventually, if we implement recorder support for flow
-    # for now this logic is handled by db-backend based on recorded lo
-    # locals
+    # for now this logic is handled by db-backend based on recorded locals
     {}
   end
 


### PR DESCRIPTION
## Summary
- avoid error if load_flow is called on an unseen path
- document placeholder `load_exprs` method

## Testing
- `ruby -c src/recorder.rb`
- `ruby -c src/trace.rb`
