### PR TITLE
Add Nix flake devshell and codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "codetracer-ruby-recorder",
+  "features": {
+    "ghcr.io/devcontainers/features/nix:1": {},
+    "ghcr.io/devcontainers-community/features/direnv:1": {}
+  },
+  "postCreateCommand": "direnv allow"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps maintain consistent coding styles
+# across different editors and IDEs
+# https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+
+[{Gemfile,Rakefile,config.ru}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+# Two trailing spaces yield a hard line break in Markdown.
+# https://spec.commonmark.org/0.30/#hard-line-breaks
+trim_trailing_whitespace = false

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: "codetracer"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.json
+!.devcontainer/devcontainer.json
+!test/fixtures/*.json
+test/tmp/
+.direnv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Instructions for Codex
+
+To run the test suite, execute:
+
+```
+just test
+```
+
+This will run the ruby test file at `test/test_tracer.rb` which traces sample programs and compares their outputs to the fixtures in `test/fixtures`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.5.22

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,4 @@
+alias t := test
+
+test:
+    ruby -Itest test/test_tracer.rb

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Metacraft Labs Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+## codetracer-ruby-recorder
+
+A recorder of Ruby programs that produces [CodeTracer](https://github.com/metacraft-labs/CodeTracer) traces.
+
+> [!WARNING]
+> Currently it is in a very early phase: we're welcoming contribution and discussion!
+
+
+### usage
+
+you can currently use it directly with
+
+```bash
+ruby trace.rb <path to ruby file>
+# produces several trace json files in the current directory
+# or in the folder of `$CODETRACER_DB_TRACE_PATH` if such an env var is defined
+```
+
+however you probably want to use it in combination with CodeTracer, which would be released soon.
+
+### env variables
+
+* if you pass `CODETRACER_RUBY_TRACER_DEBUG=1`, you enables some additional debug-related logging
+* `CODETRACER_DB_TRACE_PATH` can be used to override the path to `trace.json` (it's used internally by codetracer as well)
+
+### Development
+
+This repository provides a Nix flake for the development shell. With direnv installed, the shell is loaded automatically when you enter the directory. Run `direnv allow` once to enable it.
+
+The same environment is configured for GitHub Codespaces via the devcontainer.
+
+## future directions
+
+The current Ruby support is a prototype. In the future, it may be expanded to function in a way to similar to the more complete implementations, e.g. [Noir](https://github.com/blocksense-network/noir/tree/blocksense/tooling/tracer).
+
+### Current approach: TracePoint API
+
+Currently we're using the TracePoint API: https://rubyapi.org/3.4/o/tracepoint .
+This is very flexible and can function with probably multiple Ruby versions out of the box. 
+However, this is limited:
+
+* it's not optimal
+* it can't track more detailed info/state, needed for some CodeTracer features(or for more optimal replays).
+
+For other languages, we've used a more deeply integrated approach: patching the interpreter or VM itself (e.g. Noir).
+
+### Possible Alternative Approaches
+
+#### Create a C extension for the VM, based on the `rb_add_event_hook2`
+
+This would be a straigh-forward port of the current code, but developed as a native extension (e.g. in C/C++ or Rust). The expected speedup will be significant.
+
+#### Patching the VM
+
+This approach may provide more depth: it can let us record more precisely calculated sub-expressions, assignments to record fields and other details required for the full CodeTracer experience.
+
+The patching can be done either directly in the source code of the VM or through a binary instrumentation framework, such as Frida. The existing [ruby-trace](https://www.nccgroup.com/us/research-blog/tool-update-ruby-trace-a-low-level-tracer-for-ruby/) project provides an example for this.
+
+#### Filtering
+
+It would be useful to have a way to record only certain intervals within the program execution, or certain functions or modules: 
+we plan on expanding the [trace format](https://github.com/metacraft-labs/runtime_tracing/) and CodeTracer' support, so that this is possible. It would let one be able to record interesting
+parts of even long-running or more heavy programs.
+
+### Contributing
+
+We'd be very happy if the community finds this useful, and if anyone wants to:
+
+* Use and test the Ruby support or CodeTracer.
+* Cooperate with us on supporting/advancing the Ruby support of [CodeTracer](https://github.com/metacraft-labs/CodeTracer).
+* Provide feedback and discuss alternative implementation ideas: in the issue tracker, or in our [discord](https://discord.gg/qSDCAFMP).
+* Provide [sponsorship](https://opencollective.com/codetracer), so we can hire dedicated full-time maintainers for this project.
+
+### Legal info
+
+LICENSE: MIT
+
+Copyright (c) 2025 Metacraft Labs Ltd

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Development environment for codetracer-ruby-recorder";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+    in {
+      devShells = forEachSystem (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [ ruby just ];
+          };
+        });
+    };
+}

--- a/src/recorder.rb
+++ b/src/recorder.rb
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Metacraft Labs Ltd
+# See LICENSE file in the project root for full license information.
+
+require 'fileutils'
+
+CallRecord = Struct.new(:function_id, :args) do
+  def to_data_for_json
+    res = to_h
+    res[:args] = res[:args].map { |(variable_id, value)| {variable_id: variable_id, value: value.to_data_for_json} }
+    res
+  end
+end
+
+FunctionRecord = Struct.new(:path_id, :line, :name) do
+  def to_data_for_json
+    to_h
+  end
+end
+
+ReturnRecord = Struct.new(:return_value) do
+  def to_data_for_json
+    res = {return_value: self.return_value.to_data_for_json}
+    res
+  end
+end
+
+StepRecord = Struct.new(:path_id, :line) do
+  def to_data_for_json
+    to_h
+  end
+end
+
+RecordEvent = Struct.new(:kind, :content, :metadata) do
+  def to_data_for_json
+    to_h
+  end
+end
+
+FullValueRecord = Struct.new(:variable_id, :value) do
+  def to_data_for_json
+    {variable_id: self.variable_id, value: value.to_data_for_json}
+  end
+end
+ 
+
+ValueRecord = Struct.new(:kind, :type_id, :i, :b, :text, :r, :msg, :elements, :is_slice, :field_values, keyword_init: true) do
+  def to_data_for_json
+    res = to_h.compact
+    if !res[:elements].nil?
+      res[:elements] = res[:elements].map(&:to_data_for_json)
+    end
+    if !res[:field_values].nil?
+      res[:field_values] = res[:field_values].map(&:to_data_for_json)
+    end
+
+    # p res
+    res
+  end
+end
+
+TypeRecord = Struct.new(:kind, :lang_type, :specific_info) do
+  def to_data_for_json
+    to_h
+  end
+end
+
+class Object
+  def to_data_for_json
+    self
+  end
+end
+
+# based on  src/gdb/debug_values.py and src/types.nim's TypeKind enum
+# TODO: improve
+
+# sync with types.nim, runtime_tracing crate
+SEQ = 0
+STRUCT = 6
+# TODO others Set
+# HashSet,
+# OrderedSet,
+# Array,
+# Varargs,
+# # seq, HashSet, OrderedSet, set and array in Nim
+# # vector and array in C++
+# # list in Python
+# # Array in Ruby
+# Instance,
+# # object in Nim
+# # struct, class in C++
+# # object in Python
+# # object in Ruby
+INT = 7
+FLOAT = 8
+STRING = 9
+CSTRING = 10
+CHAR = 11
+BOOL = 12
+RAW = 16
+ERROR = 24
+NONE = 30
+
+NONE_TYPE_SPECIFIC_INFO = {kind: 'None'}
+
+$STEP_COUNT = 0
+
+class TraceRecord
+  # part of the final trace
+  attr_accessor :steps, :calls, :variables, :events, :types, :flow, :paths
+  
+  # internal helpers
+  attr_accessor :stack, :step_stack, :exprs, :tracing
+  attr_accessor :t1, :t2, :t3, :t4 # tracepoints
+  attr_accessor :codetracer_id
+
+  def initialize
+    @events = []
+
+    @steps = []
+    @calls = []
+    @variables = []
+    @types = []
+    @flow = []
+    @paths = []
+
+    @path_map = {}
+    @function_map = {}
+    @variable_map = {}
+    @type_map = {}
+    @struct_type_versions = {}
+    @stack = []
+    @step_stack = []
+    @exprs = {}
+    @tracing = false
+    @t1 = nil
+    @t2 = nil
+    @t3 = nil
+    @codetracer_id = 0
+  end
+
+  def load_flow(path, line, binding)
+    unless @exprs.key?(path)
+      @exprs[path] = load_exprs(path)
+    end
+    path_exprs = @exprs[path]
+    line_exprs = path_exprs[line]
+    if !line_exprs.nil?
+      line_exprs.map do |name|
+        [name, binding.eval(name)]
+      end
+    else
+      []
+    end
+  end
+
+  def path_id(path)
+    existing_id = @path_map[path]
+    unless existing_id.nil?
+      existing_id
+    else
+      @events << [:Path, path]
+      path_id = @path_map.count
+      @path_map[path] = path_id
+      @paths << path
+      path_id
+    end
+  end
+  
+  def register_step(path, line)
+    step_record = StepRecord.new(self.path_id(path), line)
+    @events << [:Step, step_record] # because we convert later to {Step: step-record}: default enum json format in serde/rust
+    # $stderr.write path, "\n"
+    $STEP_COUNT += 1
+    if $STEP_COUNT % 1_000 == 0
+      $stdout.write "steps ", $STEP_COUNT, "\n"
+    end
+  end
+
+  def register_call(path, line, name, args)
+    function_id = self.load_function_id(path, line, name)
+    @events << [:Call, CallRecord.new(function_id, args)]
+  end
+
+  def load_function_id(path, line, name)
+    function_id = @function_map[name]
+    if function_id.nil?
+      function_id = @function_map.count
+      @function_map[name] = function_id
+      @events << [:Function, FunctionRecord.new(self.path_id(path), line, name)]
+    end
+    function_id
+  end
+
+  def register_variable(name, value)
+    @events << [:Value, FullValueRecord.new(load_variable_id(name), value)]
+  end
+
+  def register_type(kind, name, specific_info)
+    # would lead to wrong type_id: different from the one before
+    raise "#{name} already in type map for register_type!" unless @type_map[name].nil?
+
+    type_id = @type_map.count
+    @type_map[name] = type_id
+    @events << [:Type, TypeRecord.new(kind, name, specific_info)]
+    type_id
+  end
+
+  def register_struct_type(name, specific_info)
+    if @struct_type_versions[name].nil?
+      @struct_type_versions[name] = 0
+    else
+      @struct_type_versions[name] += 1
+    end
+    struct_name_index = @struct_type_versions[name]
+    name_version = "#{name} (##{struct_name_index})"
+    register_type(STRUCT, name_version, specific_info)
+  end
+
+  def drop_last_step
+    @events << [:DropLastStep]
+  end
+
+  def load_type_id(kind, name)
+    type_id = @type_map[name]
+    if type_id.nil?
+      type_id = register_type(kind, name, NONE_TYPE_SPECIFIC_INFO)
+    end
+    type_id
+  end
+
+  def load_variable_id(name)
+    variable_id = @variable_map[name]
+    if variable_id.nil?
+      variable_id = @variable_map.count
+      @variable_map[name] = variable_id
+      @events << [:VariableName, name]
+    end
+    variable_id
+  end
+
+  def load_exprs(path)
+    # TODO: eventually, if we implement recorder support for flow
+    # for now this logic is handled by db-backend based on recorded locals
+    {}
+  end
+
+  def serialize(program)
+    if ENV["CODETRACER_RUBY_TRACER_DEBUG"] == "1"
+      pp @events
+    end
+
+    output = @events.map { |kind, event| [[kind, event.to_data_for_json]].to_h }
+
+    metadata_output = {
+      program: program,
+      args: ARGV,
+      workdir: Dir.pwd
+    }
+    # pp output
+    
+    json_output = JSON.pretty_generate(output)
+    metadata_json_output = JSON.pretty_generate(metadata_output)
+    paths_json_output = JSON.pretty_generate($codetracer_record.paths)
+
+    trace_path = ENV["CODETRACER_DB_TRACE_PATH"] || "trace.json"
+    trace_folder = File.dirname(trace_path)
+    FileUtils.mkdir_p(trace_folder)
+    trace_metadata_path = File.join(trace_folder , "trace_metadata.json")
+    trace_paths_path = File.join(trace_folder , "trace_paths.json")
+    
+    # p trace_path, json_output
+    File.write(trace_path, json_output)
+    File.write(trace_metadata_path, metadata_json_output)
+    File.write(trace_paths_path, paths_json_output)
+    
+    $stderr.write("=================================================\n")
+    $stderr.write("codetracer ruby tracer: saved trace to #{trace_folder}\n")
+  end
+end
+
+##################
+
+record = TraceRecord.new
+$codetracer_record = record
+
+INT_TYPE_INDEX = record.load_type_id(INT, "Integer")
+STRING_TYPE_INDEX = record.load_type_id(STRING, "String")
+BOOL_TYPE_INDEX = record.load_type_id(BOOL, "Bool")
+SYMBOL_TYPE_INDEX = record.load_type_id(STRING, "Symbol")
+NO_TYPE_INDEX = record.load_type_id(ERROR, "No type")
+
+# IMPORTANT: sync with common_types.nim / runtime_tracing EventLogKind
+EVENT_KIND_WRITE = 0
+EVENT_KIND_ERROR = 11
+
+def int_value(i)
+  ValueRecord.new(kind: 'Int', type_id: INT_TYPE_INDEX, i: i)
+end
+
+def string_value(text)
+  ValueRecord.new(kind: 'String', type_id: STRING_TYPE_INDEX, text: text)
+end
+
+def symbol_value(text)
+   # TODO store symbol in a more special way?
+   ValueRecord.new(kind: 'String', type_id: SYMBOL_TYPE_INDEX, text: text)
+end
+
+def raw_obj_value(raw, class_name)
+  ti = $codetracer_record.load_type_id(RAW, class_name)
+  ValueRecord.new(kind: 'Raw', type_id: ti, r: raw)
+end
+
+def sequence_value(elements)
+  ti = $codetracer_record.load_type_id(SEQ, "Array")
+  ValueRecord.new(kind: 'Sequence', type_id: ti, elements: elements, is_slice: false)
+end
+
+# fields: Array of [String, TypeRecord]
+def struct_value(class_name, field_names, field_values, depth)
+  field_ct_values = field_values.map { |value| to_value(value, depth - 1) }
+  specific_info = {
+    kind: "Struct",
+    fields: field_names.zip(field_ct_values).map do |(name, value)|
+      {name: name, type_id: value.type_id}
+    end
+  }
+  # for now: unique type for each struct instance, because
+  # fields can change (dynamic language)
+  # we can still reuse a single type most of the time
+  # or make it more flexible, but TODO for now
+  ti = $codetracer_record.register_struct_type(class_name, specific_info)
+  ValueRecord.new(kind: 'Struct', type_id: ti, field_values: field_ct_values)
+end
+
+TRUE_VALUE = ValueRecord.new(kind: 'Bool', type_id: BOOL_TYPE_INDEX, b: true)
+FALSE_VALUE = ValueRecord.new(kind: 'Bool', type_id: BOOL_TYPE_INDEX, b: false)
+NOT_SUPPORTED_VALUE = ValueRecord.new(kind: 'Error', type_id: NO_TYPE_INDEX, msg: "not supported")
+NIL_VALUE = ValueRecord.new(kind: 'None', type_id: NO_TYPE_INDEX)
+
+
+$VALUE_COUNT = 0
+
+MAX_COUNT = 5000
+
+def to_value(v, depth=10)
+  if depth <= 0
+    return NIL_VALUE
+  end
+  $VALUE_COUNT += 1
+  if $VALUE_COUNT % 10_000 == 0
+    $stderr.write("value #{$VALUE_COUNT}\n")
+  end
+  case v
+  when Integer
+    int_value(v)
+  when String
+    string_value(v)
+  when Symbol
+    symbol_value(v)
+  when true
+    TRUE_VALUE
+  when false
+    FALSE_VALUE
+  when nil
+    NIL_VALUE
+  when Array
+    if v.count > MAX_COUNT
+      # $stderr.write "array count ", v.count, "\n"
+      NOT_SUPPORTED_VALUE # TODO: non-expanded/other hint?
+    else
+      sequence_value(v.map do |element|
+        to_value(element, depth - 1)
+      end)
+    end
+  when Object
+    # NOT_SUPPORTED_VALUE
+    field_names = v.instance_variables.map { |name| name.to_s[1..] }
+    field_values = v.instance_variables.map do |name|
+      v.instance_variable_get(name)
+    end
+    struct_value(v.class.name, field_names, field_values, depth)
+  else
+    NOT_SUPPORTED_VALUE
+  end
+end
+
+NO_KEY = -1
+NO_STEP = -1

--- a/src/trace.rb
+++ b/src/trace.rb
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Metacraft Labs Ltd
+# See LICENSE file in the project root for full license information.
+
+require 'json'
+require_relative 'recorder'
+
+if ARGV[0].nil?
+  $stderr.puts("ruby trace.rb <program> [<args>]")
+  exit(1)
+end
+
+program = ARGV[0]
+
+# Warning:
+# probably related to our development env:
+# if we hit an `incompatible library version` error, like
+# `<internal:/nix/store/w8r0c0l4i8383dr0w7iiy390dgrp6ws8-ruby-3.1.5/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:136:in `require': incompatible library version - /home/alexander92/.local/share/gem/ruby/3.1.0/gems/strscan-3.1.0/lib/strscan.so (LoadError)
+# or
+# `<internal:/nix/store/w8r0c0l4i8383dr0w7iiy390dgrp6ws8-ruby-3.1.5/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:136:in `require': incompatible library version - /home/alexander92/.local/share/gem/ruby/3.1.0/gems/json-2.7.2/lib/json/ext/parser.so (LoadError)`
+#
+# it seems clearing `~/.local/share/gem` fixes things up
+# however this seems as a risky solution, as it clears global gem state!
+# BE CAREFUL if you have other ruby projects/data there!
+
+# override some of the IO methods to record them for event log
+module Kernel
+  alias :old_p :p
+  alias :old_puts :puts
+  alias :old_print :print
+
+  def p(*args)
+    if $tracer.tracing
+      $tracer.deactivate
+      $tracer.record_event(caller, args.join("\n"))
+      $tracer.activate
+    end
+    old_p(*args)
+  end
+
+  def puts(*args)
+    if $tracer.tracing
+      $tracer.deactivate
+      $tracer.record_event(caller, args.join("\n"))
+      $tracer.activate
+    end
+    old_puts(*args)
+  end
+
+  def print(*args)
+    if $tracer.tracing
+      $tracer.deactivate
+      $tracer.record_event(caller, args.join("\n"))
+      $tracer.activate
+    end
+    old_print(*args)
+  end
+
+end
+
+# class IO
+#   alias :old_write :write
+
+#   def write(name, content="", offset=0, opt=nil)
+#     if $tracer.tracing
+#       $tracer.deactivate
+#       $tracer.record_event(caller, content)
+#       $tracer.activate
+#     end
+#     old_write(name, content, offset, opt)
+#   end
+# end
+
+class Tracer
+  attr_accessor :calls_tracepoint, :return_tracepoint,
+                :line_tracepoint, :raise_tracepoint, :tracing
+
+  attr_reader :ignore_list, :record
+
+  def initialize(record)
+    @tracing = false
+    @trace_stopped = false
+    @record = record
+    @ignore_list = []
+  end
+
+  def stop_tracing
+    @trace_stopped = true
+    @tracing = false
+  end
+
+  def tracks_call?(tp)
+    tp.path.end_with?('.rb') && !@ignore_list.any? { |path| tp.path.include?(path) }
+  end
+
+  def ignore(path)
+    @ignore_list << path
+  end
+
+  def prepare_args(tp)
+    args_after_self = tp.parameters.map do |(kind, name)|
+      value = if tp.binding.nil? || name.nil?
+          NIL_VALUE
+        else
+          begin
+            to_value(tp.binding.local_variable_get(name))
+          rescue
+            NIL_VALUE
+          end
+        end
+      [name.to_sym, value]
+    end
+
+    # can be class or module
+    module_name = tp.self.class.name
+    begin
+      args = [[:self, raw_obj_value(tp.self.to_s, module_name)]] + args_after_self
+    rescue
+      # $stderr.write("error args\n")
+      args = []
+    end
+
+    args.each do |(name, value)|
+      @record.register_variable(name, value)
+    end
+
+    arg_records = args.map do |(name, value)|
+      [@record.load_variable_id(name), value]
+    end
+
+    arg_records
+  end
+
+  def record_call(tp)
+    if self.tracks_call?(tp)
+      module_name = tp.self.class.name
+      method_name_prefix = module_name == 'Object' ? '' :  "#{module_name}#"
+      method_name = "#{method_name_prefix}#{tp.method_id}"
+
+      old_puts "call #{method_name} with #{tp.parameters}"
+
+      arg_records = prepare_args(tp)
+
+      @record.register_step(tp.path, tp.lineno)
+      @record.register_call(tp.path, tp.lineno, method_name, arg_records)
+    else
+    end
+  end
+
+  def record_return(tp)
+    if self.tracks_call?(tp)
+      old_puts "return"
+      return_value = to_value(tp.return_value)
+      @record.register_step(tp.path, tp.lineno)
+      # return value support inspired by existing IDE-s/envs like 
+      # Visual Studio/JetBrains IIRC
+      # (Nikola Gamzakov showed me some examples)
+      @record.register_variable("<return_value>", return_value)
+      @record.events << [:Return, ReturnRecord.new(return_value)]
+    end
+
+    def record_step(tp)
+      if self.tracks_call?(tp)
+        @record.register_step(tp.path, tp.lineno)
+        variables = self.load_variables(tp.binding)
+        variables.each do |(name, value)|
+          @record.register_variable(name, value)
+        end
+      end
+    end
+
+    def record_event(caller, content)
+      # reason/effect are on different steps:
+      # reason: before `p` is called;
+      # effect: now, when the args are evaluated 
+      # which can happen after many calls/steps;
+      # maybe add a step for this call?
+      begin
+        location = caller[0].split[0].split(':')[0..1]
+        path, line = location[0], location[1].to_i
+        @record.register_step(path, line)
+      rescue
+        # ignore for now: we'll just jump to last previous step 
+        # which might be from args
+      end
+      # start is last step on this level: log for reason: the previous step on this level 
+      @record.events << [:Event, RecordEvent.new(EVENT_KIND_WRITE, content, "")]
+    end
+
+    def record_exception(tp)
+      @record.events << [:Event, RecordEvent.new(EVENT_KIND_ERROR, tp.raised_exception.to_s, "")]
+    end
+  end
+
+  def activate
+    if !@trace_stopped
+      @calls_tracepoint.enable
+      @return_tracepoint.enable
+      @line_tracepoint.enable
+      @raise_tracepoint.enable
+      @tracing = true
+    end
+  end
+
+  def deactivate
+    @tracing = false
+    @calls_tracepoint.disable
+    @return_tracepoint.disable
+    @line_tracepoint.disable
+    @raise_tracepoint.disable
+  end
+
+  private
+  
+  def load_variables(binding)
+    if !binding.nil?
+      # $stdout.write binding.local_variables
+      binding.local_variables.map do |name|
+        v = binding.local_variable_get(name)
+        out = to_value(v)
+        [name, out]
+      end
+    else
+      []
+    end
+  end  
+end
+
+
+$tracer = Tracer.new($codetracer_record)
+
+# also possible :c_call, :b_call: for now record ruby calls (:call)
+# c_call: c lang
+# b_call: block entry
+# https://rubyapi.org/3.4/o/tracepoint
+$tracer.calls_tracepoint = TracePoint.new(:call) do |tp|
+  $tracer.deactivate
+  $tracer.record_call(tp)
+  $tracer.activate
+end
+
+$tracer.return_tracepoint = TracePoint.new(:return) do |tp|
+  $tracer.deactivate
+  $tracer.record_return(tp)
+  $tracer.activate
+end
+
+$tracer.line_tracepoint = TracePoint.new(:line) do |tp|
+  $tracer.deactivate
+  $tracer.record_step(tp)
+  $tracer.activate
+end
+
+$tracer.raise_tracepoint = TracePoint.new(:raise) do |tp|
+  $tracer.deactivate
+  $tracer.record_exception(tp)
+  $tracer.activate
+end
+
+$tracer.record.register_call("", 1, "<top-level>", [])
+$tracer.ignore('lib/ruby')
+$tracer.ignore('trace.rb')
+$tracer.ignore('recorder.rb')
+$tracer.ignore('<internal:')
+$tracer.ignore('gems/')
+  
+
+trace_args = ARGV
+ARGV = ARGV[1..-1]
+$tracer.activate
+begin
+  Kernel.load(program)
+rescue Exception => e
+  # important: rescue Exception,
+  # not just rescue as we originally did
+  # because a simple `rescue` doesn't catch some errors
+  # like SystemExit and others
+  # (when we call `exit` in the trace program and others)
+  # https://stackoverflow.com/questions/5118745/is-systemexit-a-special-kind-of-exception
+  old_puts ""
+  old_puts "==== trace.rb error while tracing program ==="
+  old_puts "ERROR"
+  old_puts e
+  old_puts e.backtrace
+  old_puts "====================="
+  old_puts ""
+end
+ARGV = trace_args
+
+$tracer.stop_tracing
+
+$tracer.record.serialize(program)

--- a/test/fixtures/addition_trace.json
+++ b/test/fixtures/addition_trace.json
@@ -1,0 +1,239 @@
+[
+  {
+    "Type": {
+      "kind": 7,
+      "lang_type": "Integer",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "String",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 12,
+      "lang_type": "Bool",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "Symbol",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 24,
+      "lang_type": "No type",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Path": ""
+  },
+  {
+    "Function": {
+      "path_id": 0,
+      "line": 1,
+      "name": "<top-level>"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 0,
+      "args": [
+
+      ]
+    }
+  },
+  {
+    "Path": "test/programs/addition.rb"
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 1
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 5
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Object",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "VariableName": "self"
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "Raw",
+        "type_id": 5,
+        "r": "main"
+      }
+    }
+  },
+  {
+    "VariableName": "a"
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 1
+      }
+    }
+  },
+  {
+    "VariableName": "b"
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 2
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 1
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 1,
+      "name": "add"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 1,
+      "args": [
+        {
+          "variable_id": 0,
+          "value": {
+            "kind": "Raw",
+            "type_id": 5,
+            "r": "main"
+          }
+        },
+        {
+          "variable_id": 1,
+          "value": {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          }
+        },
+        {
+          "variable_id": 2,
+          "value": {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          }
+        }
+      ]
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 2
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 1
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 2
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 3
+    }
+  },
+  {
+    "VariableName": "<return_value>"
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 5
+    }
+  },
+  {
+    "Event": {
+      "kind": 0,
+      "content": "3",
+      "metadata": ""
+    }
+  }
+]

--- a/test/fixtures/array_sum_trace.json
+++ b/test/fixtures/array_sum_trace.json
@@ -1,0 +1,528 @@
+[
+  {
+    "Type": {
+      "kind": 7,
+      "lang_type": "Integer",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "String",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 12,
+      "lang_type": "Bool",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "Symbol",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 24,
+      "lang_type": "No type",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Path": ""
+  },
+  {
+    "Function": {
+      "path_id": 0,
+      "line": 1,
+      "name": "<top-level>"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 0,
+      "args": [
+
+      ]
+    }
+  },
+  {
+    "Path": "test/programs/array_sum.rb"
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 1
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 9
+    }
+  },
+  {
+    "Type": {
+      "kind": 0,
+      "lang_type": "Array",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Object",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "VariableName": "self"
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "Raw",
+        "type_id": 6,
+        "r": "main"
+      }
+    }
+  },
+  {
+    "VariableName": "arr"
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 1
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 1,
+      "name": "sum"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 1,
+      "args": [
+        {
+          "variable_id": 0,
+          "value": {
+            "kind": "Raw",
+            "type_id": 6,
+            "r": "main"
+          }
+        },
+        {
+          "variable_id": 1,
+          "value": {
+            "kind": "Sequence",
+            "type_id": 5,
+            "elements": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 1
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 2
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 3
+              }
+            ],
+            "is_slice": false
+          }
+        }
+      ]
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 2
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "VariableName": "total"
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 3
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 0
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 4
+    }
+  },
+  {
+    "VariableName": "n"
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 1
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 0
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 4
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 2
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 1
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 4
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 6
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 5,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 6
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 7
+    }
+  },
+  {
+    "VariableName": "<return_value>"
+  },
+  {
+    "Value": {
+      "variable_id": 4,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 6
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 6
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 9
+    }
+  },
+  {
+    "Event": {
+      "kind": 0,
+      "content": "6",
+      "metadata": ""
+    }
+  }
+]

--- a/test/fixtures/point_representation_trace.json
+++ b/test/fixtures/point_representation_trace.json
@@ -1,0 +1,352 @@
+[
+  {
+    "Type": {
+      "kind": 7,
+      "lang_type": "Integer",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "String",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 12,
+      "lang_type": "Bool",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "Symbol",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 24,
+      "lang_type": "No type",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Path": ""
+  },
+  {
+    "Function": {
+      "path_id": 0,
+      "line": 1,
+      "name": "<top-level>"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 0,
+      "args": [
+
+      ]
+    }
+  },
+  {
+    "Path": "test/programs/point_representation.rb"
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 1
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 2
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 3
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 8
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 13
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Point",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "VariableName": "self"
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "Raw",
+        "type_id": 5,
+        "r": "(, )"
+      }
+    }
+  },
+  {
+    "VariableName": "x"
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "VariableName": "y"
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 4
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 3
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 3,
+      "name": "Point#initialize"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 1,
+      "args": [
+        {
+          "variable_id": 0,
+          "value": {
+            "kind": "Raw",
+            "type_id": 5,
+            "r": "(, )"
+          }
+        },
+        {
+          "variable_id": 1,
+          "value": {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        },
+        {
+          "variable_id": 2,
+          "value": {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 4
+          }
+        }
+      ]
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 4
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 4
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 5
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 3
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 4
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 6
+    }
+  },
+  {
+    "VariableName": "<return_value>"
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 4
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "Int",
+        "type_id": 0,
+        "i": 4
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "Raw",
+        "type_id": 5,
+        "r": "(3, 4)"
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 8
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 8,
+      "name": "Point#to_s"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 2,
+      "args": [
+        {
+          "variable_id": 0,
+          "value": {
+            "kind": "Raw",
+            "type_id": 5,
+            "r": "(3, 4)"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 9
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 10
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "String",
+        "type_id": 1,
+        "text": "(3, 4)"
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "String",
+        "type_id": 1,
+        "text": "(3, 4)"
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 13
+    }
+  },
+  {
+    "Event": {
+      "kind": 0,
+      "content": "(3, 4)",
+      "metadata": ""
+    }
+  }
+]

--- a/test/programs/addition.rb
+++ b/test/programs/addition.rb
@@ -1,0 +1,5 @@
+def add(a, b)
+  a + b
+end
+
+puts add(1, 2)

--- a/test/programs/array_sum.rb
+++ b/test/programs/array_sum.rb
@@ -1,0 +1,9 @@
+def sum(arr)
+  total = 0
+  arr.each do |n|
+    total += n
+  end
+  total
+end
+
+puts sum([1, 2, 3])

--- a/test/programs/point_representation.rb
+++ b/test/programs/point_representation.rb
@@ -1,0 +1,13 @@
+class Point
+  attr_accessor :x, :y
+  def initialize(x, y)
+    @x = x
+    @y = y
+  end
+
+  def to_s
+    "(#{@x}, #{@y})"
+  end
+end
+
+p Point.new(3, 4).to_s

--- a/test/test_tracer.rb
+++ b/test/test_tracer.rb
@@ -1,0 +1,37 @@
+require 'minitest/autorun'
+require 'json'
+require 'fileutils'
+
+class TraceTest < Minitest::Test
+  TMP_DIR = File.expand_path('tmp', __dir__)
+  FIXTURE_DIR = File.expand_path('fixtures', __dir__)
+
+  def setup
+    FileUtils.mkdir_p(TMP_DIR)
+  end
+
+  def run_trace(program_name)
+    base = File.basename(program_name, '.rb')
+    Dir.chdir(File.expand_path('..', __dir__)) do
+      program = File.join('test', 'programs', program_name)
+      output = File.join('test', 'tmp', "#{base}_trace.json")
+      env = { 'CODETRACER_DB_TRACE_PATH' => output }
+      system(env, 'ruby', 'src/trace.rb', program)
+      raise "trace failed" unless $?.success?
+    end
+    JSON.parse(File.read(File.join(TMP_DIR, "#{base}_trace.json")))
+  end
+
+  def expected_trace(program_name)
+    base = File.basename(program_name, '.rb')
+    fixture = File.join(FIXTURE_DIR, "#{base}_trace.json")
+    JSON.parse(File.read(fixture))
+  end
+
+  Dir.glob(File.join(FIXTURE_DIR, '*_trace.json')).each do |fixture|
+    base = File.basename(fixture, '_trace.json')
+    define_method("test_#{base}") do
+      assert_equal expected_trace("#{base}.rb"), run_trace("#{base}.rb")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- provide a flake-based development shell with ruby and just
- ignore direnv folder and allow devcontainer config
- describe the Nix/devcontainer workflow in the README
- use direnv to load the flake shell automatically
- configure GitHub Codespaces with nix and direnv

## Testing
- `ruby -Itest test/test_tracer.rb`