### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: Setup just
+        uses: extractions/setup-just@v1
+      - name: Run tests
+        run: just test
+
+  nix:
+    runs-on: ubuntu-latest
+    container:
+      image: nixos/nix:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests via Nix
+        run: nix develop -c just test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running tests on Ubuntu, macOS, Windows
- add Nix job running tests in a NixOS container

## Testing
- `just test` *(fails: `just` not found)*