### PR TITLE
Fix Nix CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
 
   nix:
     runs-on: ubuntu-latest
-    container:
-      image: nixos/nix:latest
     steps:
       - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-24.05
+          extra_nix_config: |
+            experimental-features = nix-command flakes
       - name: Run tests via Nix
         run: nix develop -c just test


### PR DESCRIPTION
## Summary
- use `cachix/install-nix-action` instead of running inside a container

## Testing
- `ruby -Itest test/test_tracer.rb`