### PR TITLE
Add benchmark directory with sample program

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/benchmarks/fixtures/*.json filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.json
 !.devcontainer/devcontainer.json
 !test/fixtures/*.json
+!test/benchmarks/fixtures/*.json
 test/tmp/
 .direnv/

--- a/Justfile
+++ b/Justfile
@@ -2,3 +2,6 @@ alias t := test
 
 test:
     ruby -Itest test/test_tracer.rb
+
+bench name="heavy_work":
+    ruby test/benchmarks/run_benchmark.rb {{name}}

--- a/test/benchmarks/fixtures/heavy_work_trace.json
+++ b/test/benchmarks/fixtures/heavy_work_trace.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:912fc0347cb8a57abd94a7defd76b147f3a79e556745e45207b89529f8a59d8b
+size 8203587

--- a/test/benchmarks/programs/heavy_work.rb
+++ b/test/benchmarks/programs/heavy_work.rb
@@ -1,0 +1,27 @@
+def prime?(n)
+  return false if n < 2
+  (2..Math.sqrt(n).floor).each do |i|
+    return false if n % i == 0
+  end
+  true
+end
+
+def primes(n)
+  arr = []
+  i = 2
+  while arr.length < n
+    arr << i if prime?(i)
+    i += 1
+  end
+  arr
+end
+
+def compute
+  arr = primes(100)
+  hash = arr.each_with_index.to_h
+  sum = arr.reduce(:+)
+  str = arr.map(&:to_s).join(',')
+  [sum, str, hash[arr.size]]
+end
+
+compute

--- a/test/benchmarks/run_benchmark.rb
+++ b/test/benchmarks/run_benchmark.rb
@@ -1,0 +1,51 @@
+require 'json'
+require 'fileutils'
+require 'digest'
+require 'benchmark'
+
+USAGE = "Usage: ruby run_benchmark.rb BENCHMARK_NAME"
+
+BENCHMARK = ARGV.shift || abort(USAGE)
+HASHES = {
+  'heavy_work' => '912fc0347cb8a57abd94a7defd76b147f3a79e556745e45207b89529f8a59d8b'
+}
+
+unless HASHES.key?(BENCHMARK)
+  abort("Unknown benchmark '#{BENCHMARK}'")
+end
+
+PROGRAM = File.expand_path("programs/#{BENCHMARK}.rb", __dir__)
+FIXTURE = File.expand_path("fixtures/#{BENCHMARK}_trace.json", __dir__)
+TMP_DIR = File.expand_path('tmp', __dir__)
+OUTPUT = File.join(TMP_DIR, "#{BENCHMARK}_trace.json")
+EXPECTED_HASH = HASHES[BENCHMARK]
+
+FileUtils.mkdir_p(TMP_DIR)
+
+unless File.exist?(FIXTURE) && Digest::SHA256.file(FIXTURE).hexdigest == EXPECTED_HASH
+  warn "Reference trace missing or corrupt. Attempting to fetch via git lfs..."
+  system('git', 'lfs', 'pull', '--include', FIXTURE)
+end
+
+raise 'reference trace unavailable' unless File.exist?(FIXTURE)
+raise 'reference trace hash mismatch' unless Digest::SHA256.file(FIXTURE).hexdigest == EXPECTED_HASH
+
+elapsed = Benchmark.realtime do
+  env = { 'CODETRACER_DB_TRACE_PATH' => OUTPUT }
+  system(env, 'ruby', File.expand_path('../../src/trace.rb', __dir__), PROGRAM)
+  raise 'trace failed' unless $?.success?
+end
+puts "Benchmark runtime: #{(elapsed * 1000).round} ms"
+
+def files_identical?(a, b)
+  cmp_result = system('cmp', '-s', a, b)
+  return $?.success? if !cmp_result.nil?
+  File.binread(a) == File.binread(b)
+end
+
+if files_identical?(FIXTURE, OUTPUT)
+  puts 'Trace matches reference.'
+else
+  warn 'Trace differs from reference!'
+  exit 1
+end


### PR DESCRIPTION
## Summary
- manage benchmark fixtures with git-lfs
- add a benchmark program that calculates prime numbers
- parametrize `run_benchmark.rb` and use system cmp when available
- add `bench` task with optional name argument to `Justfile`
- record benchmark results with `run_benchmark.rb`

## Testing
- `just test` *(fails: command not found)*
- `ruby -Itest test/test_tracer.rb`