### PR TITLE
Add packaging for native extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !test/benchmarks/fixtures/*.json
 test/tmp/
 .direnv/
+pkg/

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rb_sys/extensiontask'
+
+RbSys::ExtensionTask.new('codetracer_ruby_native_recorder') do |ext|
+  ext.ext_dir = 'ext/native_tracer'
+  ext.lib_dir = 'src'
+  ext.gem_spec = Gem::Specification.load('codetracer-ruby-recorder.gemspec')
+end

--- a/codetracer-ruby-recorder.gemspec
+++ b/codetracer-ruby-recorder.gemspec
@@ -1,0 +1,17 @@
+Gem::Specification.new do |spec|
+  spec.name          = 'codetracer-ruby-recorder'
+  spec.version       = '0.1.0'
+  spec.authors       = ['Metacraft Labs']
+  spec.email         = ['info@metacraft-labs.com']
+
+  spec.summary       = 'CodeTracer Ruby recorder with native extension'
+  spec.description   = 'Ruby tracer that records execution steps via a Rust native extension.'
+  spec.license       = 'MIT'
+  spec.homepage      = 'https://github.com/metacraft-labs/codetracer-ruby-recorder'
+
+  spec.files         = Dir['src/**/*', 'ext/native_tracer/**/{Cargo.toml,*.rs}', 'ext/native_tracer/extconf.rb', 'README.md', 'LICENSE']
+  spec.require_paths = ['src']
+  spec.extensions    = ['ext/native_tracer/extconf.rb']
+
+  spec.add_development_dependency 'rb_sys', '~> 0.9'
+end

--- a/ext/native_tracer/Cargo.toml
+++ b/ext/native_tracer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "codetracer_ruby_native_recoreder"
+name = "codetracer_ruby_native_recorder"
 version = "0.1.0"
 edition = "2021" # latest stable Rust edition
 description = "Native Ruby tracer using rb_add_event_hook2"

--- a/ext/native_tracer/README.md
+++ b/ext/native_tracer/README.md
@@ -1,4 +1,4 @@
-# codetracer_ruby_native_recoreder
+# codetracer_ruby_native_recorder
 
 This crate provides a minimal Ruby tracer implemented in Rust.
 It registers a Ruby VM event hook using `rb_add_event_hook2` and
@@ -17,8 +17,39 @@ If you have `just` installed, run `just build-extension` from the project root.
 The produced shared library can be required from Ruby:
 
 ```ruby
-require_relative 'target/release/libcodetracer_ruby_native_recoreder'
+require_relative 'target/release/libcodetracer_ruby_native_recorder'
 ```
 
 Once loaded, the tracer starts writing a trace to `trace.json` or the
 path specified via the `CODETRACER_DB_TRACE_PATH` environment variable.
+
+## Publishing platform-specific gems
+
+This extension can be packaged as a Ruby gem so the compiled library is
+distributed for each target platform. The gemspec at the project root uses
+[`rb_sys`](https://github.com/oxidize-rb/rb-sys) to build the library.
+
+To publish prebuilt binaries:
+
+1. Install the development dependencies:
+
+   ```bash
+   bundle install
+   ```
+
+2. For each target triple, set `RB_SYS_CARGO_TARGET` and run the packaging task:
+
+   ```bash
+   RB_SYS_CARGO_TARGET=x86_64-unknown-linux-gnu rake cross_native_gem
+   ```
+
+   Replace the target triple with the platform you want to build for, e.g.
+   `aarch64-apple-darwin` or `x86_64-pc-windows-msvc`.
+
+3. Push the generated gem from the `pkg/` directory to RubyGems:
+
+   ```bash
+   gem push pkg/codetracer-ruby-recorder-0.1.0-x86_64-linux.gem
+   ```
+
+Repeat these steps for each platform to provide platform-specific gems.

--- a/ext/native_tracer/extconf.rb
+++ b/ext/native_tracer/extconf.rb
@@ -1,0 +1,4 @@
+require 'mkmf'
+require 'rb_sys/mkmf'
+
+create_rust_makefile('codetracer_ruby_native_recorder')

--- a/ext/native_tracer/src/lib.rs
+++ b/ext/native_tracer/src/lib.rs
@@ -23,7 +23,7 @@ extern "C" fn event_hook(ev: rb_event_flag_t, _data: VALUE, _self: VALUE, _mid: 
 }
 
 #[no_mangle]
-pub extern "C" fn Init_codetracer_ruby_native_recoreder() {
+pub extern "C" fn Init_codetracer_ruby_native_recorder() {
     unsafe {
         let out = std::env::var("CODETRACER_DB_TRACE_PATH").unwrap_or_else(|_| "trace.json".to_string());
         let file = std::fs::File::create(out).expect("failed to create trace output");


### PR DESCRIPTION
## Summary
- rename native library to `codetracer_ruby_native_recorder`
- package native extension with `rb_sys`
- provide publishing instructions in the extension README

## Testing
- `ruby -Itest test/test_tracer.rb`