### PR TITLE
Add native tracer command-line utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ ruby trace.rb <path to ruby file>
 # or in the folder of `$CODETRACER_DB_TRACE_PATH` if such an env var is defined
 ```
 
+You can also invoke a lightweight CLI that loads the native tracer extension
+directly:
+
+```bash
+ruby src/native_trace.rb <path to ruby file>
+```
+
 however you probably want to use it in combination with CodeTracer, which would be released soon.
 
 ### Development

--- a/src/native_trace.rb
+++ b/src/native_trace.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# SPDX-License-Identifier: MIT
+# Simple utility loading the native tracer extension and executing a program.
+
+if ARGV.empty?
+  $stderr.puts("usage: ruby native_trace.rb <program> [args]")
+  exit 1
+end
+
+# Path to the compiled native extension
+ext_path = File.expand_path('../ext/native_tracer/target/release/libcodetracer_ruby_recorder', __dir__)
+require ext_path
+
+program = ARGV.shift
+load program
+


### PR DESCRIPTION
## Summary
- provide minimal CLI `src/native_trace.rb` that loads the compiled native tracer
- document CLI usage in the README

## Testing
- `just build-extension`
- `just test`
