### PR TITLE
Add CLI out-dir option and rename env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,34 @@ A recorder of Ruby programs that produces [CodeTracer](https://github.com/metacr
 > Currently it is in a very early phase: we're welcoming contribution and discussion!
 
 
-### usage
+### Usage
 
 you can currently use it directly with
 
 ```bash
-ruby trace.rb <path to ruby file>
-# produces several trace json files in the current directory
-# or in the folder of `$CODETRACER_DB_TRACE_PATH` if such an env var is defined
+ruby trace.rb [--out-dir DIR] <path to ruby file>
+# produces several trace json files in DIR,
+# or in `$CODETRACER_RUBY_RECORDER_OUT_DIR` if DIR is not provided.
+# Defaults to the current directory.
+# Pass --help to list all options.
 ```
 
 You can also invoke a lightweight CLI that loads the native tracer extension
 directly:
 
 ```bash
-ruby src/native_trace.rb <path to ruby file>
+ruby src/native_trace.rb [--out-dir DIR] <path to ruby file>
+# Uses DIR or `$CODETRACER_RUBY_RECORDER_OUT_DIR` to choose where traces are saved.
 ```
 
 however you probably want to use it in combination with CodeTracer, which would be released soon.
 
-### env variables
+### ENV variables
 
 * if you pass `CODETRACER_RUBY_TRACER_DEBUG=1`, you enables some additional debug-related logging
-* `CODETRACER_DB_TRACE_PATH` can be used to override the path to `trace.json` (it's used internally by codetracer as well)
+* `CODETRACER_RUBY_RECORDER_OUT_DIR` can be used to specify the directory for trace files
 
-## future directions
+## Future directions
 
 The current Ruby support is a prototype. In the future, it may be expanded to function in a way to similar to the more complete implementations, e.g. [Noir](https://github.com/blocksense-network/noir/tree/blocksense/tooling/tracer).
 

--- a/ext/native_tracer/README.md
+++ b/ext/native_tracer/README.md
@@ -20,8 +20,9 @@ The produced shared library can be required from Ruby:
 require_relative 'target/release/libcodetracer_ruby_recorder'
 ```
 
-Once loaded, the tracer starts writing a trace to `trace.json` or the
-path specified via the `CODETRACER_DB_TRACE_PATH` environment variable.
+Once loaded, the tracer starts writing a trace to `trace.json` in the
+directory specified via the `CODETRACER_RUBY_RECORDER_OUT_DIR` environment
+variable (defaults to the current directory).
 
 ## Publishing platform-specific gems
 

--- a/src/native_trace.rb
+++ b/src/native_trace.rb
@@ -2,10 +2,28 @@
 # SPDX-License-Identifier: MIT
 # Simple utility loading the native tracer extension and executing a program.
 
+require 'optparse'
+
+options = {}
+parser = OptionParser.new do |opts|
+  opts.banner = "usage: ruby native_trace.rb [options] <program> [args]"
+  opts.on('-o DIR', '--out-dir DIR', 'Directory to write trace files') do |dir|
+    options[:out_dir] = dir
+  end
+  opts.on('-h', '--help', 'Print this help') do
+    puts opts
+    exit
+  end
+end
+parser.order!
+
 if ARGV.empty?
-  $stderr.puts("usage: ruby native_trace.rb <program> [args]")
+  $stderr.puts parser
   exit 1
 end
+
+out_dir = options[:out_dir] || ENV['CODETRACER_RUBY_RECORDER_OUT_DIR'] || Dir.pwd
+ENV['CODETRACER_RUBY_RECORDER_OUT_DIR'] = out_dir
 
 # Path to the compiled native extension
 ext_path = File.expand_path('../ext/native_tracer/target/release/libcodetracer_ruby_recorder', __dir__)

--- a/test/test_tracer.rb
+++ b/test/test_tracer.rb
@@ -14,12 +14,12 @@ class TraceTest < Minitest::Test
     base = File.basename(program_name, '.rb')
     Dir.chdir(File.expand_path('..', __dir__)) do
       program = File.join('test', 'programs', program_name)
-      output = File.join('test', 'tmp', "#{base}_trace.json")
-      env = { 'CODETRACER_DB_TRACE_PATH' => output }
-      system(env, 'ruby', 'src/trace.rb', program)
+      out_dir = File.join('test', 'tmp', base)
+      FileUtils.mkdir_p(out_dir)
+      system('ruby', 'src/trace.rb', '--out-dir', out_dir, program)
       raise "trace failed" unless $?.success?
+      JSON.parse(File.read(File.join(out_dir, 'trace.json')))
     end
-    JSON.parse(File.read(File.join(TMP_DIR, "#{base}_trace.json")))
   end
 
   def expected_trace(program_name)


### PR DESCRIPTION
## Summary
- add `--out-dir` option for tracer utilities
- default to `CODETRACER_RUBY_RECORDER_OUT_DIR` or current dir
- rename env variable in code, docs and tests
- document new usage and env var in README

## Testing
- `just test`
- `just bench`
- `just build-extension`
