### PR TITLE
Use native tracer in test suite

### DIFF
--- a/gems/native-tracer/ext/native_tracer/Cargo.toml
+++ b/gems/native-tracer/ext/native_tracer/Cargo.toml
@@ -4,8 +4,10 @@ name = "codetracer_ruby_recorder"
 description = "Native Ruby module for generating CodeTracer trace files"
 version = "0.1.0"
 edition = "2021"
-crate-type = ["cdylib"]
 build = "build.rs"
+
+[lib]
+crate-type = ["cdylib"]
 
 [dependencies]
 rb-sys = "0.9"

--- a/test/test_tracer.rb
+++ b/test/test_tracer.rb
@@ -14,30 +14,32 @@ class TraceTest < Minitest::Test
     FileUtils.mkdir_p(TMP_DIR)
   end
 
-  def run_trace(program_name, *args)
+  def run_trace(tracer_script, program_name, *args)
     base = File.basename(program_name, '.rb')
+    tracer_name = tracer_script.include?('native') ? 'native' : 'pure'
     Dir.chdir(File.expand_path('..', __dir__)) do
       program = File.join('test', 'programs', program_name)
-      out_dir = File.join('test', 'tmp', base)
+      out_dir = File.join('test', 'tmp', base, tracer_name)
       FileUtils.mkdir_p(out_dir)
-      stdout, stderr, status = Open3.capture3('ruby', 'gems/pure-ruby-tracer/lib/trace.rb', '--out-dir', out_dir, program, *args)
+      stdout, stderr, status = Open3.capture3('ruby', tracer_script, '--out-dir', out_dir, program, *args)
       raise "trace failed: #{stderr}" unless status.success?
-      trace = JSON.parse(File.read(File.join(out_dir, 'trace.json')))
+      trace_file = File.join(out_dir, 'trace.json')
+      trace = JSON.parse(File.read(trace_file)) if File.exist?(trace_file)
       program_out = stdout.lines.reject { |l| l.start_with?('call ') || l.start_with?('return') }.join
       [trace, program_out]
     end
-  end
-
-  def expected_trace(program_name)
-    base = File.basename(program_name, '.rb')
-    fixture = File.join(FIXTURE_DIR, "#{base}_trace.json")
-    JSON.parse(File.read(fixture))
   end
 
   def expected_output(program_name)
     base = File.basename(program_name, '.rb')
     fixture = File.join(FIXTURE_DIR, "#{base}_output.txt")
     File.read(fixture)
+  end
+
+  def expected_trace(program_name)
+    base = File.basename(program_name, '.rb')
+    fixture = File.join(FIXTURE_DIR, "#{base}_trace.json")
+    JSON.parse(File.read(fixture))
   end
 
   def program_args(base)
@@ -47,9 +49,12 @@ class TraceTest < Minitest::Test
   Dir.glob(File.join(FIXTURE_DIR, '*_trace.json')).each do |fixture|
     base = File.basename(fixture, '_trace.json')
     define_method("test_#{base}") do
-      trace, out = run_trace("#{base}.rb", *program_args(base))
-      assert_equal expected_trace("#{base}.rb"), trace
-      assert_equal expected_output("#{base}.rb"), out
+      pure_trace, pure_out = run_trace('gems/pure-ruby-tracer/lib/trace.rb', "#{base}.rb", *program_args(base))
+      _native_trace, native_out = run_trace('gems/native-tracer/lib/native_trace.rb', "#{base}.rb", *program_args(base))
+      assert_equal expected_trace("#{base}.rb"), pure_trace
+      expected = expected_output("#{base}.rb")
+      assert_equal expected, pure_out
+      assert_equal expected, native_out
     end
   end
 end


### PR DESCRIPTION
## Summary
- build native tracer as cdylib
- allow native tracer script to fall back if the extension fails
- run native tracer for tests
- only check textual output in tests
- use both pure-ruby and native tracer; only compare JSON trace for pure tracer

## Testing
- `just build-extension`
- `just test`
