### PR TITLE
Fix native tracer loading and assert non-empty trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           ruby-version: '3.2'
       - name: Setup just
         uses: extractions/setup-just@v1
+      - name: Build extension
+        run: just build-extension
       - name: Run tests
         run: just test
 
@@ -32,5 +34,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-24.05
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - name: Build extension via Nix
+        run: nix develop -c just build-extension
       - name: Run tests via Nix
         run: nix develop -c just test

--- a/gems/native-tracer/lib/native_trace.rb
+++ b/gems/native-tracer/lib/native_trace.rb
@@ -3,6 +3,8 @@
 # Simple utility loading the native tracer extension and executing a program.
 
 require 'optparse'
+require 'fileutils'
+require 'rbconfig'
 
 options = {}
 parser = OptionParser.new do |opts|
@@ -27,10 +29,20 @@ ENV['CODETRACER_RUBY_RECORDER_OUT_DIR'] = out_dir
 
 # Path to the compiled native extension
 ext_dir = File.expand_path('../ext/native_tracer/target/release', __dir__)
-target_path = File.join(ext_dir, 'codetracer_ruby_recorder.so')
+dlext = RbConfig::CONFIG['DLEXT']
+target_path = File.join(ext_dir, "codetracer_ruby_recorder.#{dlext}")
 unless File.exist?(target_path)
-  alt_path = File.join(ext_dir, 'libcodetracer_ruby_recorder.so')
-  target_path = alt_path if File.exist?(alt_path)
+  extensions = %w[so bundle dylib dll]
+  alt_path = extensions
+             .map { |ext| File.join(ext_dir, "libcodetracer_ruby_recorder.#{ext}") }
+             .find { |path| File.exist?(path) }
+  if alt_path
+    begin
+      File.symlink(alt_path, target_path)
+    rescue StandardError
+      FileUtils.cp(alt_path, target_path)
+    end
+  end
 end
 
 recorder = nil

--- a/test/test_tracer.rb
+++ b/test/test_tracer.rb
@@ -50,11 +50,18 @@ class TraceTest < Minitest::Test
     base = File.basename(fixture, '_trace.json')
     define_method("test_#{base}") do
       pure_trace, pure_out = run_trace('gems/pure-ruby-tracer/lib/trace.rb', "#{base}.rb", *program_args(base))
-      _native_trace, native_out = run_trace('gems/native-tracer/lib/native_trace.rb', "#{base}.rb", *program_args(base))
+      native_trace, native_out = run_trace('gems/native-tracer/lib/native_trace.rb', "#{base}.rb", *program_args(base))
+
       assert_equal expected_trace("#{base}.rb"), pure_trace
       expected = expected_output("#{base}.rb")
       assert_equal expected, pure_out
       assert_equal expected, native_out
+
+      # The native tracer doesn't yet match the pure Ruby tracer, but it should
+      # still generate some trace output. Fail early if the trace is empty to
+      # ensure the extension was loaded correctly.
+      refute_nil native_trace, 'native tracer did not produce a trace file'
+      refute_empty native_trace, 'native tracer produced an empty trace'
     end
   end
 end


### PR DESCRIPTION
## Summary
- ensure native tracer extension can be loaded across operating systems
- check in tests that the native tracer produced a non-empty trace

## Testing
- `just build-extension`
- `just test`
