### PR TITLE
Guard Ruby tracer output by env var

### DIFF
--- a/gems/pure-ruby-tracer/lib/recorder.rb
+++ b/gems/pure-ruby-tracer/lib/recorder.rb
@@ -4,6 +4,8 @@
 
 require 'fileutils'
 
+DEBUG_TRACER = ENV['CODETRACER_RUBY_TRACER_DEBUG'] == '1'
+
 CallRecord = Struct.new(:function_id, :args) do
   def to_data_for_json
     res = to_h
@@ -246,9 +248,7 @@ class TraceRecord
   end
 
   def serialize(program, out_dir = nil)
-    if ENV["CODETRACER_RUBY_TRACER_DEBUG"] == "1"
-      pp @events
-    end
+    pp @events if DEBUG_TRACER
 
     output = @events.map { |kind, event| [[kind, event.to_data_for_json]].to_h }
 
@@ -277,8 +277,10 @@ class TraceRecord
     File.write(trace_metadata_path, metadata_json_output)
     File.write(trace_paths_path, paths_json_output)
 
-    $stderr.write("=================================================\n")
-    $stderr.write("codetracer ruby tracer: saved trace to #{trace_folder}\n")
+    if DEBUG_TRACER
+      $stderr.write("=================================================\n")
+      $stderr.write("codetracer ruby tracer: saved trace to #{trace_folder}\n")
+    end
   end
 end
 
@@ -353,7 +355,7 @@ def to_value(v, depth=10)
   end
   $VALUE_COUNT += 1
   if $VALUE_COUNT % 10_000 == 0
-    $stderr.write("value #{$VALUE_COUNT}\n")
+    $stderr.write("value #{$VALUE_COUNT}\n") if DEBUG_TRACER
   end
   case v
   when Integer

--- a/gems/pure-ruby-tracer/lib/trace.rb
+++ b/gems/pure-ruby-tracer/lib/trace.rb
@@ -6,6 +6,8 @@ require 'json'
 require 'optparse'
 require_relative 'recorder'
 
+DEBUG_TRACER = ENV['CODETRACER_RUBY_TRACER_DEBUG'] == '1'
+
 # Warning:
 # probably related to our development env:
 # if we hit an `incompatible library version` error, like
@@ -158,7 +160,7 @@ class Tracer
       method_name_prefix = module_name == 'Object' ? '' :  "#{module_name}#"
       method_name = "#{method_name_prefix}#{tp.method_id}"
 
-      old_puts "call #{method_name} with #{tp.parameters}"
+      old_puts "call #{method_name} with #{tp.parameters}" if DEBUG_TRACER
 
       arg_records = prepare_args(tp)
 
@@ -170,7 +172,7 @@ class Tracer
 
   def record_return(tp)
     if self.tracks_call?(tp)
-      old_puts "return"
+      old_puts "return" if DEBUG_TRACER
       return_value = to_value(tp.return_value)
       @record.register_step(tp.path, tp.lineno)
       # return value support inspired by existing IDE-s/envs like
@@ -281,13 +283,15 @@ if __FILE__ == $PROGRAM_NAME
   begin
     Kernel.load(program)
   rescue Exception => e
-    old_puts ''
-    old_puts '==== trace.rb error while tracing program ==='
-    old_puts 'ERROR'
-    old_puts e
-    old_puts e.backtrace
-    old_puts '====================='
-    old_puts ''
+    if DEBUG_TRACER
+      old_puts ''
+      old_puts '==== trace.rb error while tracing program ==='
+      old_puts 'ERROR'
+      old_puts e
+      old_puts e.backtrace
+      old_puts '====================='
+      old_puts ''
+    end
   end
 
   $tracer.stop_tracing


### PR DESCRIPTION
## Summary
- conditionally emit tracer debug output based on `CODETRACER_RUBY_TRACER_DEBUG`
- cache env lookup to reduce overhead
- restore warning from native tracer

## Testing
- `just build-extension`
- `just test`
