### PR TITLE
Pass debug mode through Tracer constructor

### DIFF
--- a/gems/pure-ruby-tracer/lib/recorder.rb
+++ b/gems/pure-ruby-tracer/lib/recorder.rb
@@ -4,8 +4,6 @@
 
 require 'fileutils'
 
-DEBUG_TRACER = ENV['CODETRACER_RUBY_TRACER_DEBUG'] == '1'
-
 CallRecord = Struct.new(:function_id, :args) do
   def to_data_for_json
     res = to_h
@@ -115,6 +113,7 @@ class TraceRecord
   attr_accessor :stack, :step_stack, :exprs, :tracing
   attr_accessor :t1, :t2, :t3, :t4 # tracepoints
   attr_accessor :codetracer_id
+  attr_accessor :debug
 
   def initialize
     @events = []
@@ -139,6 +138,7 @@ class TraceRecord
     @t2 = nil
     @t3 = nil
     @codetracer_id = 0
+    @debug = false
   end
 
   def load_flow(path, line, binding)
@@ -248,7 +248,7 @@ class TraceRecord
   end
 
   def serialize(program, out_dir = nil)
-    pp @events if DEBUG_TRACER
+    pp @events if @debug
 
     output = @events.map { |kind, event| [[kind, event.to_data_for_json]].to_h }
 
@@ -277,7 +277,7 @@ class TraceRecord
     File.write(trace_metadata_path, metadata_json_output)
     File.write(trace_paths_path, paths_json_output)
 
-    if DEBUG_TRACER
+    if @debug
       $stderr.write("=================================================\n")
       $stderr.write("codetracer ruby tracer: saved trace to #{trace_folder}\n")
     end
@@ -355,7 +355,7 @@ def to_value(v, depth=10)
   end
   $VALUE_COUNT += 1
   if $VALUE_COUNT % 10_000 == 0
-    $stderr.write("value #{$VALUE_COUNT}\n") if DEBUG_TRACER
+    $stderr.write("value #{$VALUE_COUNT}\n") if $codetracer_record.debug
   end
   case v
   when Integer


### PR DESCRIPTION
## Summary
- remove global DEBUG_TRACER constant
- let `Tracer` accept a `debug` flag and read the ENV variable during initialization
- propagate debug flag to `TraceRecord`
- update debug checks in tracer and recorder

## Testing
- `just test`