### PR TITLE
Add ruby platform gem publishing

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -89,6 +89,14 @@ ruby scripts/publish_gems.rb
 
 Repeat these steps for each supported platform.
 
+Afterwards build a generic gem for the `ruby` platform which installs the
+extension at install time:
+
+```bash
+rake build
+gem push pkg/codetracer-ruby-recorder-<version>.gem
+```
+
 ### Pure Ruby gem
 
 The pure Ruby tracer is packaged from the files under `src/`. Build and

--- a/gems/native-tracer/ext/native_tracer/README.md
+++ b/gems/native-tracer/ext/native_tracer/README.md
@@ -54,3 +54,11 @@ To publish prebuilt binaries:
    ```
 
 Repeat these steps for each platform to provide platform-specific gems.
+
+After building the platform-specific variants, build a generic gem that
+compiles the extension when installed:
+
+```bash
+rake build
+gem push pkg/codetracer-ruby-recorder-<version>.gem
+```

--- a/scripts/publish_gems.rb
+++ b/scripts/publish_gems.rb
@@ -27,6 +27,12 @@ TARGETS.each do |target|
   FileUtils.rm_f(gem_file)
 end
 
+# Build and publish fallback gem for generic Ruby platform
+run('rake build')
+generic_gem = Dir['pkg/codetracer-ruby-recorder-*.gem'].max_by { |f| File.mtime(f) }
+run("gem push #{generic_gem}")
+FileUtils.rm_f(generic_gem)
+
 # Build and publish pure Ruby gem
 run('gem build gems/pure-ruby-tracer/codetracer_pure_ruby_recorder.gemspec')
 pure_gem = Dir['codetracer_pure_ruby_recorder-*.gem'].max_by { |f| File.mtime(f) }


### PR DESCRIPTION
## Summary
- publish a generic Ruby gem in `publish_gems.rb`
- update maintainer docs about the new gem
- document how to build and push the fallback gem in the extension readme

## Testing
- `just build-extension`
- `just test`
