### PR TITLE
Add configurable gem target list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -64,6 +64,10 @@ A helper script is available to build and push all gems in one go:
 ruby scripts/publish_gems.rb
 ```
 
+The list of target triples used by the script lives in
+`scripts/targets.txt`. You can override it by passing targets as
+arguments to the helper script.
+
 ### Native extension gem
 
 1. Install the development dependencies:

--- a/scripts/publish_gems.rb
+++ b/scripts/publish_gems.rb
@@ -3,14 +3,20 @@
 
 require 'fileutils'
 
-TARGETS = [
-  'x86_64-unknown-linux-gnu',
-  'aarch64-unknown-linux-gnu',
-  'x86_64-apple-darwin',
-  'aarch64-apple-darwin',
-  'x86_64-pc-windows-msvc'
-].freeze
+def load_targets
+  return ARGV unless ARGV.empty?
 
+  config_path = File.join(__dir__, 'targets.txt')
+  unless File.exist?(config_path)
+    abort("No targets specified and #{config_path} is missing")
+  end
+
+  File.readlines(config_path, chomp: true)
+      .map { |l| l.strip }
+      .reject { |l| l.empty? || l.start_with?('#') }
+end
+
+TARGETS = load_targets.freeze
 
 def run(cmd, env = {})
   command = env.map { |k, v| "#{k}=#{v}" }.join(' ')

--- a/scripts/targets.txt
+++ b/scripts/targets.txt
@@ -1,0 +1,5 @@
+x86_64-unknown-linux-gnu
+aarch64-unknown-linux-gnu
+x86_64-apple-darwin
+aarch64-apple-darwin
+x86_64-pc-windows-msvc


### PR DESCRIPTION
## Summary
- load gem publish targets from `scripts/targets.txt` or ARGV
- describe target list location in MAINTAINERS guide

## Testing
- `just test`
