### PR TITLE
Add gem installation test

### DIFF
--- a/gems/native-tracer/codetracer-ruby-recorder.gemspec
+++ b/gems/native-tracer/codetracer-ruby-recorder.gemspec
@@ -9,10 +9,14 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.homepage      = 'https://github.com/metacraft-labs/codetracer-ruby-recorder'
 
-  spec.files         = Dir['lib/**/*', 'ext/native_tracer/**/{Cargo.toml,*.rs}',
-                          'ext/native_tracer/extconf.rb', '../../README.md', '../../LICENSE']
+  spec.files         = Dir[
+    'lib/**/*',
+    'ext/native_tracer/**/{Cargo.toml,*.rs}',
+    'ext/native_tracer/extconf.rb',
+    'ext/native_tracer/target/release/*'
+  ]
   spec.require_paths = ['lib']
-  spec.extensions    = ['ext/native_tracer/extconf.rb']
+  spec.extensions    = []
   spec.bindir        = 'bin'
   spec.executables   = ['codetracer-ruby-recorder']
 

--- a/gems/pure-ruby-tracer/codetracer_pure_ruby_recorder.gemspec
+++ b/gems/pure-ruby-tracer/codetracer_pure_ruby_recorder.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.homepage      = 'https://github.com/metacraft-labs/codetracer-ruby-recorder'
 
-  spec.files         = Dir['lib/**/*', 'bin/*', '../../README.md', '../../LICENSE']
+  spec.files         = Dir['lib/**/*', 'bin/*']
   spec.require_paths = ['lib']
   spec.bindir        = 'bin'
   spec.executables   = ['codetracer-pure-ruby-recorder']


### PR DESCRIPTION
## Summary
- adjust gemspecs to include prebuilt extension and drop references outside of gem directories
- add test verifying the native gem can be built and installed
- also test installation of the pure-ruby tracer gem

## Testing
- `just test`
