### PR TITLE
Support more Ruby types

### DIFF
--- a/gems/pure-ruby-tracer/lib/recorder.rb
+++ b/gems/pure-ruby-tracer/lib/recorder.rb
@@ -46,7 +46,7 @@ FullValueRecord = Struct.new(:variable_id, :value) do
 end
 
 
-ValueRecord = Struct.new(:kind, :type_id, :i, :b, :text, :r, :msg, :elements, :is_slice, :field_values, keyword_init: true) do
+ValueRecord = Struct.new(:kind, :type_id, :i, :f, :b, :text, :r, :msg, :elements, :is_slice, :field_values, keyword_init: true) do
   def to_data_for_json
     res = to_h.compact
     if !res[:elements].nil?
@@ -402,7 +402,7 @@ def to_value(v, depth=10)
     end
   when Range
     struct_value('Range', ['begin', 'end'], [v.begin, v.end], depth)
-  when defined?(Set) && v.is_a?(Set)
+  when ->(o) { defined?(Set) && o.is_a?(Set) }
     if v.size > MAX_COUNT
       NOT_SUPPORTED_VALUE
     else
@@ -414,7 +414,7 @@ def to_value(v, depth=10)
     struct_value('Regexp', ['source', 'options'], [v.source, v.options], depth)
   when Struct
     struct_value(v.class.name, v.members.map(&:to_s), v.values, depth)
-  when defined?(OpenStruct) && v.is_a?(OpenStruct)
+  when ->(o) { defined?(OpenStruct) && o.is_a?(OpenStruct) }
     h = v.to_h
     pairs = h.map do |k, val|
       struct_value('Pair', ['k', 'v'], [k, val], depth)

--- a/test/fixtures/more_types_trace.json
+++ b/test/fixtures/more_types_trace.json
@@ -157,5 +157,378 @@
         "kind": "None"
       }
     }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Pair (#0)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "k",
+            "type_id": 3
+          },
+          {
+            "name": "v",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Pair (#1)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "k",
+            "type_id": 3
+          },
+          {
+            "name": "v",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 0,
+      "lang_type": "Hash",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Range (#0)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "begin",
+            "type_id": 0
+          },
+          {
+            "name": "end",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 0,
+      "lang_type": "Set",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Time (#0)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "sec",
+            "type_id": 0
+          },
+          {
+            "name": "nsec",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Regexp (#0)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "source",
+            "type_id": 1
+          },
+          {
+            "name": "options",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Point (#0)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "x",
+            "type_id": 0
+          },
+          {
+            "name": "y",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Pair (#2)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "k",
+            "type_id": 3
+          },
+          {
+            "name": "v",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Pair (#3)",
+      "specific_info": {
+        "kind": "Struct",
+        "fields": [
+          {
+            "name": "k",
+            "type_id": 3
+          },
+          {
+            "name": "v",
+            "type_id": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 0,
+      "lang_type": "Array",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "Sequence",
+        "type_id": 16,
+        "elements": [
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 1.5
+          },
+          {
+            "kind": "Sequence",
+            "type_id": 8,
+            "elements": [
+              {
+                "kind": "Struct",
+                "type_id": 6,
+                "field_values": [
+                  {
+                    "kind": "String",
+                    "type_id": 3,
+                    "text": "a"
+                  },
+                  {
+                    "kind": "Int",
+                    "type_id": 0,
+                    "i": 1
+                  }
+                ]
+              },
+              {
+                "kind": "Struct",
+                "type_id": 7,
+                "field_values": [
+                  {
+                    "kind": "String",
+                    "type_id": 3,
+                    "text": "b"
+                  },
+                  {
+                    "kind": "Int",
+                    "type_id": 0,
+                    "i": 2
+                  }
+                ]
+              }
+            ],
+            "is_slice": false
+          },
+          {
+            "kind": "Struct",
+            "type_id": 9,
+            "field_values": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 1
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 3
+              }
+            ]
+          },
+          {
+            "kind": "Sequence",
+            "type_id": 10,
+            "elements": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 1
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 2
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 3
+              }
+            ],
+            "is_slice": false
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 0
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 0
+              }
+            ]
+          },
+          {
+            "kind": "Struct",
+            "type_id": 12,
+            "field_values": [
+              {
+                "kind": "String",
+                "type_id": 1,
+                "text": "ab"
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 0
+              }
+            ]
+          },
+          {
+            "kind": "Struct",
+            "type_id": 13,
+            "field_values": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 5
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 6
+              }
+            ]
+          },
+          {
+            "kind": "Sequence",
+            "type_id": 8,
+            "elements": [
+              {
+                "kind": "Struct",
+                "type_id": 14,
+                "field_values": [
+                  {
+                    "kind": "String",
+                    "type_id": 3,
+                    "text": "foo"
+                  },
+                  {
+                    "kind": "Int",
+                    "type_id": 0,
+                    "i": 7
+                  }
+                ]
+              },
+              {
+                "kind": "Struct",
+                "type_id": 15,
+                "field_values": [
+                  {
+                    "kind": "String",
+                    "type_id": 3,
+                    "text": "bar"
+                  },
+                  {
+                    "kind": "Int",
+                    "type_id": 0,
+                    "i": 8
+                  }
+                ]
+              }
+            ],
+            "is_slice": false
+          }
+        ],
+        "is_slice": false
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 29
+    }
+  },
+  {
+    "Event": {
+      "kind": 0,
+      "content": "1.5\n{:a=>1, :b=>2}\n1..3\n#<Set: {1, 2, 3}>\n1970-01-01 00:00:00 +0000\n(?-mix:ab)\n#<struct Point x=5, y=6>\n#<OpenStruct foo=7, bar=8>",
+      "metadata": ""
+    }
   }
 ]


### PR DESCRIPTION
## Notes
- Adjusted pure Ruby recorder to properly handle `Set` and `OpenStruct` detection
- Native tracer now tracks versions of struct types to match recorder output
- Updated fixture for the `more_types` example

## Summary
- capture struct type versions in the native tracer
- fix type detection for `Set` and `OpenStruct` in the recorder
- regenerate fixture with extended type info

## Testing
- `just build-extension`
- `just test`