### PR TITLE
Update benchmark usage documentation

### DIFF
--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -6,4 +6,13 @@ The reference traces are stored via Git LFS so the repository stays lightweight.
 
 At the moment there is a single benchmark (`heavy_work`) that exercises a mixture of array and hash operations while computing prime numbers. More benchmarks will be added as we expand the suite.
 
-Use `run_benchmarks.rb --write-report=console BENCHMARKS_DIR` to execute a single benchmark and print the runtime. Passing a path ending with `.json` or `.svg` will run all benchmarks and write a report in the chosen format.
+Use `run_benchmarks.rb` to execute the benchmarks. The first argument is a glob
+pattern that selects which benchmark(s) to run. For example, to run the
+`heavy_work` benchmark and print the timings to the console:
+
+```
+$ ruby run_benchmarks.rb heavy_work --write-report=console
+```
+
+Passing a path ending with `.json` or `.svg` will run all benchmarks and write a
+report in the chosen format.


### PR DESCRIPTION
## Summary
- document how to select benchmarks using a glob pattern
- show example invocation matching the OptionParser banner

## Testing
- `just test`