### PR TITLE
Fix outdated native trace path

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,7 +23,7 @@ just build-extension
 
 This compiles the extension in release mode using Cargo. The resulting
 shared library is placed under
-`ext/native_tracer/target/release/` and is loaded by `src/native_trace.rb`.
+`ext/native_tracer/target/release/` and is loaded by `gems/native-tracer/lib/native_trace.rb`.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can also invoke a lightweight CLI that loads the native tracer extension
 directly:
 
 ```bash
-ruby src/native_trace.rb [--out-dir DIR] <path to ruby file>
+ruby gems/native-tracer/lib/native_trace.rb [--out-dir DIR] <path to ruby file>
 # Uses DIR or `$CODETRACER_RUBY_RECORDER_OUT_DIR` to choose where traces are saved.
 ```
 


### PR DESCRIPTION
## Summary
- update native tracer CLI path in README
- fix reference in MAINTAINERS guide

## Testing
- `just build-extension`
- `just test`