### PR TITLE
Add library API for pure Ruby tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ gem install codetracer_pure_ruby_recorder
 After installing, load the tracer:
 
 ```ruby
-require 'codetracer_ruby_recorder'
+require 'codetracer_ruby_recorder' # native implementation
+# require 'codetracer_pure_ruby_recorder' # pure Ruby implementation
 
 recorder = RubyRecorder.new
 recorder.enable_tracing

--- a/examples/selective_tracing_pure.rb
+++ b/examples/selective_tracing_pure.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# Load the pure Ruby tracer library if RubyRecorder is not already defined
+unless defined?(RubyRecorder)
+  lib_base = File.expand_path('../gems/pure-ruby-tracer/lib/codetracer_pure_ruby_recorder', __dir__)
+  require lib_base
+end
+
+recorder = RubyRecorder.new
+
+puts 'start trace'
+recorder.disable_tracing
+puts 'this will not be traced'
+recorder.enable_tracing
+puts 'this will be traced'
+recorder.disable_tracing
+puts 'tracing disabled'
+recorder.flush_trace(Dir.pwd)

--- a/gems/pure-ruby-tracer/lib/codetracer_pure_ruby_recorder.rb
+++ b/gems/pure-ruby-tracer/lib/codetracer_pure_ruby_recorder.rb
@@ -1,0 +1,43 @@
+require_relative 'trace'
+
+# Ruby implementation of the RubyRecorder API used by the native tracer.
+# Provides basic tracing controls and serialization using the pure Ruby tracer.
+class RubyRecorder
+  def initialize(debug: ENV['CODETRACER_RUBY_RECORDER_DEBUG'] == '1')
+    @record = $codetracer_record
+    @tracer = Tracer.new(@record, debug: debug)
+    setup_defaults
+  end
+
+  # Enable tracing of Ruby code execution.
+  def enable_tracing
+    @tracer.activate
+  end
+
+  # Disable tracing without discarding collected data.
+  def disable_tracing
+    @tracer.deactivate
+  end
+
+  # Serialize the trace to +out_dir+.
+  def flush_trace(out_dir)
+    @tracer.stop_tracing
+    @record.serialize('', out_dir)
+  end
+
+  # Record a custom event at +path+ and +line+ with +content+.
+  def record_event(path, line, content)
+    @tracer.record_event(["#{path}:#{line}"], content)
+  end
+
+  private
+
+  def setup_defaults
+    @record.register_call('', 1, '<top-level>', [])
+    @tracer.ignore('lib/ruby')
+    @tracer.ignore('trace.rb')
+    @tracer.ignore('recorder.rb')
+    @tracer.ignore('<internal:')
+    @tracer.ignore('gems/')
+  end
+end


### PR DESCRIPTION
## Summary
- expose a RubyRecorder class for the pure Ruby tracer
- avoid patching Kernel when used as a library
- document how to require the pure Ruby implementation
- add an example demonstrating selective tracing with the pure Ruby tracer

## Testing
- `just build-extension`
- `just test`