### PR TITLE
Add automated gem release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish Gems
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+      - name: Setup just
+        uses: extractions/setup-just@v1
+      - name: Publish gems
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: ruby scripts/publish_gems.rb

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -120,3 +120,23 @@ packages can be used interchangeably.
 
 All the above steps are automated by `scripts/publish_gems.rb` which
 builds and publishes the pure Ruby gem and all native variants.
+
+### Automated publishing via GitHub Actions
+
+Gems are published automatically when a tag matching `v<version>` is
+pushed. The workflow defined in `.github/workflows/publish.yml` checks
+that the tag version equals the versions in both gemspecs and then runs
+`scripts/publish_gems.rb`.
+
+The workflow requires a RubyGems API key stored as a repository secret
+named `RUBYGEMS_API_KEY`. Obtain the key with `gem signin` and copy the
+`rubygems_api_key` value from `~/.gem/credentials`. Add it under
+`Settings → Secrets and variables → Actions` in the repository so the
+workflow can authenticate with RubyGems.
+
+To release a new version:
+
+1. Update the `version` field in both gemspecs.
+2. Commit the changes and create an annotated tag `v<version>`.
+3. Push the tag to GitHub. The workflow will build and publish the
+   gems if the tag matches the versions.

--- a/scripts/publish_gems.rb
+++ b/scripts/publish_gems.rb
@@ -2,6 +2,25 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'rubygems'
+
+def gem_version(path)
+  Gem::Specification.load(path).version.to_s
+end
+
+def ensure_tag_matches_version
+  tag = ENV['GITHUB_REF_NAME'] || ENV['RELEASE_TAG'] || `git describe --tags --exact-match`.strip
+  tag = tag.sub(/^v/, '')
+
+  native_version = gem_version(File.join('gems', 'native-tracer', 'codetracer-ruby-recorder.gemspec'))
+  pure_version   = gem_version(File.join('gems', 'pure-ruby-tracer', 'codetracer_pure_ruby_recorder.gemspec'))
+
+  unless tag == native_version && tag == pure_version
+    abort("Tag #{tag} does not match gem versions #{native_version} and #{pure_version}")
+  end
+end
+
+ensure_tag_matches_version
 
 def load_targets
   return ARGV unless ARGV.empty?


### PR DESCRIPTION
## Summary
- automate gem publishing on tag push
- verify tag version matches gemspecs before publishing
- document GitHub credentials and release process

## Testing
- `just build-extension` *(fails: command not found)*
- `just test` *(fails: command not found)*