### PR TITLE
Refactor: Introduce Codetracer::KernelPatches module

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 alias t := test
 
 test:
-    ruby -Itest test/test_tracer.rb
+    ruby -Itest test/test_kernel_patches.rb test/test_tracer.rb
 
 bench pattern="*" write_report="console":
     ruby test/benchmarks/run_benchmarks.rb '{{pattern}}' --write-report={{write_report}}

--- a/codetracer/kernel_patches.rb
+++ b/codetracer/kernel_patches.rb
@@ -14,6 +14,10 @@ module Codetracer
         @@original_methods[:print] = Kernel.instance_method(:print)
 
         Kernel.module_eval do
+          alias_method :old_p, :p unless method_defined?(:old_p)
+          alias_method :old_puts, :puts unless method_defined?(:old_puts)
+          alias_method :old_print, :print unless method_defined?(:old_print)
+
           define_method(:p) do |*args|
             loc = caller_locations(1,1).first
             @@tracers.each do |t|
@@ -33,7 +37,7 @@ module Codetracer
           define_method(:print) do |*args|
             loc = caller_locations(1,1).first
             @@tracers.each do |t|
-              t.record_event(loc.path, loc.lineno, args.join("\n"))
+              t.record_event(loc.path, loc.lineno, args.join)
             end
             @@original_methods[:print].bind(self).call(*args)
           end

--- a/codetracer/kernel_patches.rb
+++ b/codetracer/kernel_patches.rb
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+module Codetracer
+  module KernelPatches
+    @@tracers = []
+    @@original_methods = {}
+
+    def self.install(tracer)
+      @@tracers << tracer
+
+      if @@original_methods.empty?
+        @@original_methods[:p] = Kernel.instance_method(:p)
+        @@original_methods[:puts] = Kernel.instance_method(:puts)
+        @@original_methods[:print] = Kernel.instance_method(:print)
+
+        Kernel.module_eval do
+          define_method(:p) do |*args|
+            loc = caller_locations(1,1).first
+            @@tracers.each do |t|
+              t.record_event(loc.path, loc.lineno, args.map(&:inspect).join("\n"))
+            end
+            @@original_methods[:p].bind(self).call(*args)
+          end
+
+          define_method(:puts) do |*args|
+            loc = caller_locations(1,1).first
+            @@tracers.each do |t|
+              t.record_event(loc.path, loc.lineno, args.join("\n"))
+            end
+            @@original_methods[:puts].bind(self).call(*args)
+          end
+
+          define_method(:print) do |*args|
+            loc = caller_locations(1,1).first
+            @@tracers.each do |t|
+              t.record_event(loc.path, loc.lineno, args.join("\n"))
+            end
+            @@original_methods[:print].bind(self).call(*args)
+          end
+        end
+      end
+    end
+
+    def self.uninstall(tracer)
+      @@tracers.delete(tracer)
+
+      if @@tracers.empty? && !@@original_methods.empty?
+        Kernel.module_eval do
+          define_method(:p, @@original_methods[:p])
+          define_method(:puts, @@original_methods[:puts])
+          define_method(:print, @@original_methods[:print])
+        end
+        @@original_methods.clear
+      end
+    end
+  end
+end

--- a/test/test_kernel_patches.rb
+++ b/test/test_kernel_patches.rb
@@ -46,9 +46,9 @@ class TestKernelPatches < Minitest::Test
   def test_patching_and_basic_event_recording
     Codetracer::KernelPatches.install(@tracer1)
 
-    expected_line_p = __LINE__ + 1; p 'hello'
-    expected_line_puts = __LINE__ + 1; puts 'world'
-    expected_line_print = __LINE__ + 1; print 'test'
+    expected_line_p = __LINE__; p 'hello'
+    expected_line_puts = __LINE__; puts 'world'
+    expected_line_print = __LINE__; print 'test'
 
     assert_equal 3, @tracer1.events.size
     
@@ -74,7 +74,7 @@ class TestKernelPatches < Minitest::Test
     Codetracer::KernelPatches.install(@tracer1)
     Codetracer::KernelPatches.install(@tracer2)
 
-    expected_line_multi = __LINE__ + 1; p 'multitest'
+    expected_line_multi = __LINE__; p 'multitest'
 
     assert_equal 1, @tracer1.events.size
     assert_equal 1, @tracer2.events.size
@@ -93,7 +93,7 @@ class TestKernelPatches < Minitest::Test
     @tracer1.clear_events
     @tracer2.clear_events
 
-    expected_line_one_left = __LINE__ + 1; p 'one left'
+    expected_line_one_left = __LINE__; p 'one left'
     
     assert_empty @tracer1.events, "Tracer1 should have no events after being uninstalled"
     assert_equal 1, @tracer2.events.size
@@ -122,9 +122,9 @@ class TestKernelPatches < Minitest::Test
 
     arg_obj = { key: "value", number: 123 }
     
-    expected_line_p_detailed = __LINE__ + 1; p "detailed_p", arg_obj
-    expected_line_puts_detailed = __LINE__ + 1; puts "detailed_puts", arg_obj.to_s
-    expected_line_print_detailed = __LINE__ + 1; print "detailed_print", arg_obj.to_s
+    expected_line_p_detailed = __LINE__; p "detailed_p", arg_obj
+    expected_line_puts_detailed = __LINE__; puts "detailed_puts", arg_obj.to_s
+    expected_line_print_detailed = __LINE__; print "detailed_print", arg_obj.to_s
 
     assert_equal 3, @tracer1.events.size
 
@@ -132,7 +132,7 @@ class TestKernelPatches < Minitest::Test
     assert_equal __FILE__, event_p[:path], "Path for p mismatch"
     assert_equal expected_line_p_detailed, event_p[:lineno], "Line number for p mismatch"
     # p calls inspect on each argument and joins with newline if multiple, but here it's one string then obj
-    assert_equal "\"detailed_p\"\n{key: \"value\", number: 123}", event_p[:content], "Content for p mismatch"
+    assert_equal "\"detailed_p\"\n{:key=>\"value\", :number=>123}", event_p[:content], "Content for p mismatch"
 
 
     event_puts = @tracer1.events[1]

--- a/test/test_kernel_patches.rb
+++ b/test/test_kernel_patches.rb
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: MIT
+
+require 'minitest/autorun'
+require_relative '../codetracer/kernel_patches' # Adjust path as necessary
+
+class MockTracer
+  attr_reader :events, :name
+
+  def initialize(name = "tracer")
+    @events = []
+    @name = name
+  end
+
+  def record_event(path, lineno, content)
+    @events << { path: path, lineno: lineno, content: content }
+  end
+
+  def clear_events
+    @events = []
+  end
+end
+
+class TestKernelPatches < Minitest::Test
+  def setup
+    @tracer1 = MockTracer.new("tracer1")
+    @tracer2 = MockTracer.new("tracer2")
+    # Ensure a clean state before each test by attempting to clear any existing tracers
+    # This is a bit of a hack, ideally KernelPatches would offer a reset or more direct access
+    current_tracers = Codetracer::KernelPatches.class_variable_get(:@@tracers).dup
+    current_tracers.each do |tracer|
+      Codetracer::KernelPatches.uninstall(tracer)
+    end
+  end
+
+  def teardown
+    # Ensure all tracers are uninstalled after each test
+    current_tracers = Codetracer::KernelPatches.class_variable_get(:@@tracers).dup
+    current_tracers.each do |tracer|
+      Codetracer::KernelPatches.uninstall(tracer)
+    end
+    # Verify that original methods are restored if no tracers are left
+    assert_empty Codetracer::KernelPatches.class_variable_get(:@@tracers), "Tracers should be empty after teardown"
+    assert_empty Codetracer::KernelPatches.class_variable_get(:@@original_methods), "Original methods should be cleared if no tracers are left"
+  end
+
+  def test_patching_and_basic_event_recording
+    Codetracer::KernelPatches.install(@tracer1)
+
+    expected_line_p = __LINE__ + 1; p 'hello'
+    expected_line_puts = __LINE__ + 1; puts 'world'
+    expected_line_print = __LINE__ + 1; print 'test'
+
+    assert_equal 3, @tracer1.events.size
+    
+    event_p = @tracer1.events[0]
+    assert_equal __FILE__, event_p[:path]
+    assert_equal expected_line_p, event_p[:lineno]
+    assert_equal "\"hello\"", event_p[:content] # p uses inspect
+
+    event_puts = @tracer1.events[1]
+    assert_equal __FILE__, event_puts[:path]
+    assert_equal expected_line_puts, event_puts[:lineno]
+    assert_equal "world", event_puts[:content]
+
+    event_print = @tracer1.events[2]
+    assert_equal __FILE__, event_print[:path]
+    assert_equal expected_line_print, event_print[:lineno]
+    assert_equal "test", event_print[:content]
+
+    Codetracer::KernelPatches.uninstall(@tracer1)
+  end
+
+  def test_multiple_tracers
+    Codetracer::KernelPatches.install(@tracer1)
+    Codetracer::KernelPatches.install(@tracer2)
+
+    expected_line_multi = __LINE__ + 1; p 'multitest'
+
+    assert_equal 1, @tracer1.events.size
+    assert_equal 1, @tracer2.events.size
+
+    event1_multi = @tracer1.events.first
+    assert_equal __FILE__, event1_multi[:path]
+    assert_equal expected_line_multi, event1_multi[:lineno]
+    assert_equal "\"multitest\"", event1_multi[:content]
+
+    event2_multi = @tracer2.events.first
+    assert_equal __FILE__, event2_multi[:path]
+    assert_equal expected_line_multi, event2_multi[:lineno]
+    assert_equal "\"multitest\"", event2_multi[:content]
+
+    Codetracer::KernelPatches.uninstall(@tracer1)
+    @tracer1.clear_events
+    @tracer2.clear_events
+
+    expected_line_one_left = __LINE__ + 1; p 'one left'
+    
+    assert_empty @tracer1.events, "Tracer1 should have no events after being uninstalled"
+    assert_equal 1, @tracer2.events.size
+
+    event2_one_left = @tracer2.events.first
+    assert_equal __FILE__, event2_one_left[:path]
+    assert_equal expected_line_one_left, event2_one_left[:lineno]
+    assert_equal "\"one left\"", event2_one_left[:content]
+
+    Codetracer::KernelPatches.uninstall(@tracer2)
+  end
+
+  def test_restoration_of_original_methods
+    Codetracer::KernelPatches.install(@tracer1)
+    Codetracer::KernelPatches.uninstall(@tracer1)
+
+    # To truly test restoration, we'd capture stdout. Here, we focus on the tracer not being called.
+    # If KernelPatches is working, uninstalling the last tracer should remove the patches.
+    p 'original restored' # This line's output will go to actual stdout
+
+    assert_empty @tracer1.events, "Tracer should not record events after being uninstalled and patches removed"
+  end
+
+  def test_correct_event_arguments
+    Codetracer::KernelPatches.install(@tracer1)
+
+    arg_obj = { key: "value", number: 123 }
+    
+    expected_line_p_detailed = __LINE__ + 1; p "detailed_p", arg_obj
+    expected_line_puts_detailed = __LINE__ + 1; puts "detailed_puts", arg_obj.to_s
+    expected_line_print_detailed = __LINE__ + 1; print "detailed_print", arg_obj.to_s
+
+    assert_equal 3, @tracer1.events.size
+
+    event_p = @tracer1.events[0]
+    assert_equal __FILE__, event_p[:path], "Path for p mismatch"
+    assert_equal expected_line_p_detailed, event_p[:lineno], "Line number for p mismatch"
+    # p calls inspect on each argument and joins with newline if multiple, but here it's one string then obj
+    assert_equal "\"detailed_p\"\n{key: \"value\", number: 123}", event_p[:content], "Content for p mismatch"
+
+
+    event_puts = @tracer1.events[1]
+    assert_equal __FILE__, event_puts[:path], "Path for puts mismatch"
+    assert_equal expected_line_puts_detailed, event_puts[:lineno], "Line number for puts mismatch"
+    # puts calls to_s on each argument and prints each on a new line
+    assert_equal "detailed_puts\n{:key=>\"value\", :number=>123}", event_puts[:content], "Content for puts mismatch"
+
+
+    event_print = @tracer1.events[2]
+    assert_equal __FILE__, event_print[:path], "Path for print mismatch"
+    assert_equal expected_line_print_detailed, event_print[:lineno], "Line number for print mismatch"
+    # print calls to_s on each argument and prints them sequentially
+    assert_equal "detailed_print{:key=>\"value\", :number=>123}", event_print[:content], "Content for print mismatch"
+    
+    Codetracer::KernelPatches.uninstall(@tracer1)
+  end
+end


### PR DESCRIPTION
This commit introduces a new module `Codetracer::KernelPatches` to centralize the monkey-patching logic for `Kernel#p`, `Kernel#puts`, and `Kernel#print`.

Key changes:
- Created `codetracer/kernel_patches.rb` for the new module.
- The `Codetracer::KernelPatches` module now manages a list of active tracers.
- Kernel methods are patched only once. Events are dispatched to all registered tracers.
- `install(tracer)` and `uninstall(tracer)` methods allow tracers to register and unregister.
- Original kernel methods are restored when the last tracer is uninstalled.
- Event recording consistently uses `caller_locations(1,1).first` for path and line info.
- Both the pure Ruby tracer (`trace.rb`) and the native tracer (`native_trace.rb`) have been updated to use this shared module.
- Added comprehensive Minitest unit tests for `Codetracer::KernelPatches` covering various scenarios including multiple tracers and method restoration.

This refactoring improves modularity, simplifies maintenance, and enables multiple tracer instances to coexist and receive kernel events simultaneously.