### PR TITLE
Fix Kernel patch module installation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 alias t := test
 
 test:
-    ruby -Itest test/test_tracer.rb
+    ruby -Itest test/test_kernel_patches.rb test/test_tracer.rb
 
 bench pattern="*" write_report="console":
     ruby test/benchmarks/run_benchmarks.rb '{{pattern}}' --write-report={{write_report}}

--- a/codetracer/kernel_patches.rb
+++ b/codetracer/kernel_patches.rb
@@ -14,6 +14,10 @@ module Codetracer
         @@original_methods[:print] = Kernel.instance_method(:print)
 
         Kernel.module_eval do
+          alias_method :old_p, :p unless method_defined?(:old_p)
+          alias_method :old_puts, :puts unless method_defined?(:old_puts)
+          alias_method :old_print, :print unless method_defined?(:old_print)
+
           define_method(:p) do |*args|
             loc = caller_locations(1,1).first
             @@tracers.each do |t|
@@ -33,7 +37,7 @@ module Codetracer
           define_method(:print) do |*args|
             loc = caller_locations(1,1).first
             @@tracers.each do |t|
-              t.record_event(loc.path, loc.lineno, args.join("\n"))
+              t.record_event(loc.path, loc.lineno, args.join)
             end
             @@original_methods[:print].bind(self).call(*args)
           end

--- a/test/test_kernel_patches.rb
+++ b/test/test_kernel_patches.rb
@@ -46,9 +46,9 @@ class TestKernelPatches < Minitest::Test
   def test_patching_and_basic_event_recording
     Codetracer::KernelPatches.install(@tracer1)
 
-    expected_line_p = __LINE__ + 1; p 'hello'
-    expected_line_puts = __LINE__ + 1; puts 'world'
-    expected_line_print = __LINE__ + 1; print 'test'
+    expected_line_p = __LINE__; p 'hello'
+    expected_line_puts = __LINE__; puts 'world'
+    expected_line_print = __LINE__; print 'test'
 
     assert_equal 3, @tracer1.events.size
     
@@ -74,7 +74,7 @@ class TestKernelPatches < Minitest::Test
     Codetracer::KernelPatches.install(@tracer1)
     Codetracer::KernelPatches.install(@tracer2)
 
-    expected_line_multi = __LINE__ + 1; p 'multitest'
+    expected_line_multi = __LINE__; p 'multitest'
 
     assert_equal 1, @tracer1.events.size
     assert_equal 1, @tracer2.events.size
@@ -93,7 +93,7 @@ class TestKernelPatches < Minitest::Test
     @tracer1.clear_events
     @tracer2.clear_events
 
-    expected_line_one_left = __LINE__ + 1; p 'one left'
+    expected_line_one_left = __LINE__; p 'one left'
     
     assert_empty @tracer1.events, "Tracer1 should have no events after being uninstalled"
     assert_equal 1, @tracer2.events.size
@@ -122,9 +122,9 @@ class TestKernelPatches < Minitest::Test
 
     arg_obj = { key: "value", number: 123 }
     
-    expected_line_p_detailed = __LINE__ + 1; p "detailed_p", arg_obj
-    expected_line_puts_detailed = __LINE__ + 1; puts "detailed_puts", arg_obj.to_s
-    expected_line_print_detailed = __LINE__ + 1; print "detailed_print", arg_obj.to_s
+    expected_line_p_detailed = __LINE__; p "detailed_p", arg_obj
+    expected_line_puts_detailed = __LINE__; puts "detailed_puts", arg_obj.to_s
+    expected_line_print_detailed = __LINE__; print "detailed_print", arg_obj.to_s
 
     assert_equal 3, @tracer1.events.size
 
@@ -132,7 +132,7 @@ class TestKernelPatches < Minitest::Test
     assert_equal __FILE__, event_p[:path], "Path for p mismatch"
     assert_equal expected_line_p_detailed, event_p[:lineno], "Line number for p mismatch"
     # p calls inspect on each argument and joins with newline if multiple, but here it's one string then obj
-    assert_equal "\"detailed_p\"\n{key: \"value\", number: 123}", event_p[:content], "Content for p mismatch"
+    assert_equal "\"detailed_p\"\n{:key=>\"value\", :number=>123}", event_p[:content], "Content for p mismatch"
 
 
     event_puts = @tracer1.events[1]


### PR DESCRIPTION
## Summary
- include only one shared kernel patches module
- require kernel patches via relative path in tracer scripts
- remove duplicated modules from gem directories

## Testing
- `just test`
