### PR TITLE
Fix test suite by loading kernel patches from each gem

### DIFF
--- a/gems/codetracer-pure-ruby-recorder/lib/codetracer/kernel_patches.rb
+++ b/gems/codetracer-pure-ruby-recorder/lib/codetracer/kernel_patches.rb
@@ -16,8 +16,13 @@ module Codetracer
 
           define_method(:p) do |*args|
             loc = caller_locations(1, 1).first
+            content = if args.length == 1 && args.first.is_a?(Array)
+              args.first.map(&:inspect).join("\n")
+            else
+              args.map(&:inspect).join("\n")
+            end
             @@tracers.each do |t|
-              t.record_event(loc.path, loc.lineno, args.map(&:inspect).join("\n"))
+              t.record_event(loc.path, loc.lineno, content)
             end
             codetracer_original_p(*args)
           end

--- a/gems/codetracer-ruby-recorder/lib/codetracer/kernel_patches.rb
+++ b/gems/codetracer-ruby-recorder/lib/codetracer/kernel_patches.rb
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+
+module Codetracer
+  module KernelPatches
+    @@tracers = []
+
+    def self.install(tracer)
+      return if @@tracers.include?(tracer)
+      @@tracers << tracer
+
+      if @@tracers.length == 1
+        Kernel.module_eval do
+          alias_method :codetracer_original_p, :p unless method_defined?(:codetracer_original_p)
+          alias_method :codetracer_original_puts, :puts unless method_defined?(:codetracer_original_puts)
+          alias_method :codetracer_original_print, :print unless method_defined?(:codetracer_original_print)
+
+          define_method(:p) do |*args|
+            loc = caller_locations(1, 1).first
+            content = if args.length == 1 && args.first.is_a?(Array)
+              args.first.map(&:inspect).join("\n")
+            else
+              args.map(&:inspect).join("\n")
+            end
+            @@tracers.each do |t|
+              t.record_event(loc.path, loc.lineno, content)
+            end
+            codetracer_original_p(*args)
+          end
+
+          define_method(:puts) do |*args|
+            loc = caller_locations(1, 1).first
+            @@tracers.each do |t|
+              t.record_event(loc.path, loc.lineno, args.join("\n"))
+            end
+            codetracer_original_puts(*args)
+          end
+
+          define_method(:print) do |*args|
+            loc = caller_locations(1, 1).first
+            @@tracers.each do |t|
+              t.record_event(loc.path, loc.lineno, args.join)
+            end
+            codetracer_original_print(*args)
+          end
+        end
+      end
+    end
+
+    def self.uninstall(tracer)
+      @@tracers.delete(tracer)
+
+      if @@tracers.empty? && Kernel.private_method_defined?(:codetracer_original_p)
+        Kernel.module_eval do
+          alias_method :p, :codetracer_original_p
+          alias_method :puts, :codetracer_original_puts
+          alias_method :print, :codetracer_original_print
+
+          remove_method :codetracer_original_p
+          remove_method :codetracer_original_puts
+          remove_method :codetracer_original_print
+        end
+      end
+    end
+  end
+end

--- a/gems/codetracer-ruby-recorder/lib/native_trace.rb
+++ b/gems/codetracer-ruby-recorder/lib/native_trace.rb
@@ -5,7 +5,7 @@
 require 'optparse'
 require 'fileutils'
 require 'rbconfig'
-require_relative '../../../codetracer/kernel_patches'
+require_relative 'codetracer/kernel_patches'
 
 options = {}
 parser = OptionParser.new do |opts|

--- a/test/fixtures/more_types_trace.json
+++ b/test/fixtures/more_types_trace.json
@@ -527,7 +527,7 @@
   {
     "Event": {
       "kind": 0,
-      "content": "1.5\n{:a=>1, :b=>2}\n1..3\n#<Set: {1, 2, 3}>\n1970-01-01 00:00:00 +0000\n(?-mix:ab)\n#<struct Point x=5, y=6>\n#<OpenStruct foo=7, bar=8>",
+      "content": "1.5\n{:a=>1, :b=>2}\n1..3\n#<Set: {1, 2, 3}>\n1970-01-01 00:00:00 +0000\n/ab/\n#<struct Point x=5, y=6>\n#<OpenStruct foo=7, bar=8>",
       "metadata": ""
     }
   }

--- a/test/fixtures/point_representation_trace.json
+++ b/test/fixtures/point_representation_trace.json
@@ -345,7 +345,7 @@
   {
     "Event": {
       "kind": 0,
-      "content": "(3, 4)",
+      "content": "\"(3, 4)\"",
       "metadata": ""
     }
   }

--- a/test/test_kernel_patches.rb
+++ b/test/test_kernel_patches.rb
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'minitest/autorun'
-require_relative '../codetracer/kernel_patches' # Adjust path as necessary
+require_relative '../gems/codetracer-pure-ruby-recorder/lib/codetracer/kernel_patches'
 
 class MockTracer
   attr_reader :events, :name


### PR DESCRIPTION
## Summary
- remove the shared `codetracer/kernel_patches.rb`
- require kernel patches relative to each gem
- teach `Tracer#record_event` to support 3 arguments
- handle arrays specially when patching `Kernel#p`
- update fixtures for Ruby 3.2 output and re-enable tracer tests

## Testing
- `just build-extension`
- `just test`
