### PR TITLE
Fix recursion when tracing recorder

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,1 +1,6 @@
-No insights yet. Please add content here and remove this line.
+When the pure Ruby recorder traces a script that holds a reference to the
+`PureRubyRecorder` instance in a local variable, the variable inspection code
+would recursively serialise the tracer's internal state. This results in an
+explosive amount of output and may appear as an infinite recursion when running
+`examples/selective_tracing_pure.rb`. To avoid this, `load_variables` now skips
+values that refer to the recorder or its `TraceRecord`.


### PR DESCRIPTION
## Summary
- avoid recording the PureRubyRecorder instance itself
- note the issue in codebase insights

## Testing
- `just build-extension`
- `just test` *(fails: "undefined method `codetracer_oirginal_print' for module `Kernel'")*

------
https://chatgpt.com/codex/tasks/task_e_6839e4dfa1ec832994f1d3f55f633463