### PR TITLE
Fix infinite recursion in pure recorder

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,1 +1,5 @@
-No insights yet. Please add content here and remove this line.
+When tracing scripts with the pure Ruby recorder, avoid including the
+`RubyRecorder` instance (or its `TraceRecord`) among the inspected local
+variables. Otherwise the serializer will descend into the tracer's own
+state which quickly explodes in size and appears as infinite recursion.
+`load_variables` filters these objects out.


### PR DESCRIPTION
## Summary
- avoid serialising the RubyRecorder instance in `load_variables`
- document the recursion problem in AGENTS insights

## Testing
- `just test`
- `ruby examples/selective_tracing_pure.rb`

------
https://chatgpt.com/codex/tasks/task_e_683a81f46ce883299ee03989ecc13a6b