### PR TITLE
Reduce manual ffi definitions

### DIFF
--- a/.agents/tasks/2025/06/28-1755-use-rb-sys-symbols
+++ b/.agents/tasks/2025/06/28-1755-use-rb-sys-symbols
@@ -1,0 +1,1 @@
+reduce extern C definitions referencing rb_sys


### PR DESCRIPTION
## Summary
- reuse rb_sys bindings for typed data, constants and trace functions
- drop custom structs for Ruby typed data
- align event hook flag enum with rb_sys

## Testing
- `just build-extension`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_68602c3d46448329926d7ecb4f9fb7c2