### PR TITLE
Add examples for reference cycles and runtime evaluation

### DIFF
--- a/.agents/tasks/2025/06/29-1415-example-cycles-exec
+++ b/.agents/tasks/2025/06/29-1415-example-cycles-exec
@@ -1,0 +1,1 @@
+Create ruby example programs for reference cycle and runtime code execution via other program

--- a/examples/code_provider.rb
+++ b/examples/code_provider.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+# Output a Ruby code snippet based on the provided identifier.
+# This simulates retrieving code from another program at runtime.
+
+snippet = ARGV.shift.to_s
+
+code = case snippet
+when '1'
+  "puts 'Hello from snippet 1'"
+when '2'
+  "msg = 'hello from snippet 2'; puts msg.upcase"
+when '3'
+  "5.times { |i| print i }; puts"
+when '4'
+  "class DynamicClass; def self.greet; puts 'greet from snippet 4'; end; end; DynamicClass.greet"
+else
+  "puts 'Default snippet'"
+end
+
+puts code
+

--- a/examples/reference_cycle.rb
+++ b/examples/reference_cycle.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+# Build a simple graph of objects with a reference cycle.
+class Node
+  attr_accessor :name, :neighbors
+
+  def initialize(name)
+    @name = name
+    @neighbors = []
+  end
+end
+
+a = Node.new('A')
+b = Node.new('B')
+c = Node.new('C')
+
+a.neighbors << b
+b.neighbors << c
+c.neighbors << a
+
+puts 'Reference cycle created: A -> B -> C -> A'
+puts "A neighbors: #{a.neighbors.map(&:name).join(', ')}"
+puts "B neighbors: #{b.neighbors.map(&:name).join(', ')}"
+puts "C neighbors: #{c.neighbors.map(&:name).join(', ')}"
+

--- a/examples/runtime_code_execution.rb
+++ b/examples/runtime_code_execution.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+# Demonstrate various ways of executing Ruby code obtained from another program.
+# The code snippet is produced by `code_provider.rb` based on a command-line
+# argument.
+
+require 'rbconfig'
+require 'tempfile'
+
+snippet_id = ARGV.shift || '1'
+provider = File.expand_path('code_provider.rb', __dir__)
+code = `#{RbConfig.ruby} #{provider} #{snippet_id}`
+
+puts "Retrieved code:\n#{code}"
+
+puts '\n[Kernel.eval]'
+eval(code)
+
+puts '\n[Binding#eval]'
+binding.eval(code)
+
+puts '\n[Object#instance_eval]'
+Object.new.instance_eval(code)
+
+puts '\n[Class#class_eval]'
+Class.new.class_eval(code)
+
+puts '\n[load from file]'
+Tempfile.create(['snippet', '.rb']) do |f|
+  f.write(code)
+  f.flush
+  load f.path
+end
+


### PR DESCRIPTION
## Summary
- provide `examples/reference_cycle.rb` to demonstrate cycles between objects
- add `examples/runtime_code_execution.rb` and `examples/code_provider.rb` for runtime execution of external code using several Ruby APIs
- keep examples out of CI

## Testing
- `just build-extension`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_68614a16d0ec8329a0fed83601769f3a