### PR TITLE
Include trace file sizes in benchmarks

### DIFF
--- a/.agents/tasks/2025/06/29-1646-include-trace-file-size
+++ b/.agents/tasks/2025/06/29-1646-include-trace-file-size
@@ -1,0 +1,1 @@
+In the benchmark reports produced by 'just bench', include the size of the produced trace files. Do this for all report types.


### PR DESCRIPTION
## Summary
- track how big each trace file is when running benchmarks
- display file sizes alongside timings in console reports
- write the new metrics in JSON and SVG outputs

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_68616d71f3cc8329b43fcde179bf2572