### PR TITLE
Optimize native tracer ID lookups

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,1 +1,6 @@
 flake.nix defines a pre-commit check using git-hooks.nix. Run 'nix develop' to install git hooks.
+
+The native tracer (Rust extension) caches frequently used Ruby method IDs and
+class constants in the `Recorder` struct. When adding new Ruby method calls,
+ensure the IDs are interned once during allocation and stored in the struct for
+reuse.

--- a/.agents/tasks/2025/06/29-2125-optimize-native-tracer
+++ b/.agents/tasks/2025/06/29-2125-optimize-native-tracer
@@ -1,0 +1,1 @@
+Read the code of the native tracer and optimize inefficiencies, compute values once where possible, ensure tests pass


### PR DESCRIPTION
## Summary
- cache common Ruby method IDs and constants in `Recorder`
- use cached IDs in `to_value`
- document optimization in codebase insights

## Testing
- `just build-extension`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6861aefed8288329946eabc09e00d6f9