### PR TITLE
Add gem packages to flake

### DIFF
--- a/.agents/tasks/2025/06/29-2139-flake-packages
+++ b/.agents/tasks/2025/06/29-2139-flake-packages
@@ -1,0 +1,1 @@
+Provide Ruby gems as packages in the Nix flake; set native extension gem as default

--- a/flake.nix
+++ b/flake.nix
@@ -88,5 +88,18 @@
           ];
       };
     });
+
+    packages = forEachSystem (system: let
+      pkgs = import nixpkgs { inherit system; };
+      buildGem = gemdir: pkgs.rubyPackages.buildRubyGem {
+        pname = builtins.baseNameOf gemdir;
+        version = builtins.readFile ./version.txt;
+        src = gemdir;
+      };
+    in {
+      codetracer-ruby-recorder = buildGem ./gems/codetracer-ruby-recorder;
+      codetracer-pure-ruby-recorder = buildGem ./gems/codetracer-pure-ruby-recorder;
+      default = self.packages.${system}.codetracer-ruby-recorder;
+    });
   };
 }


### PR DESCRIPTION
## Summary
- expose Ruby gems as flake packages using `buildRubyGem`
- set `codetracer-ruby-recorder` gem as the default package

## Testing
- `just build-extension`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6861b1a851c08329b1ee7cb8b6b3718b