### PR TITLE
Add Nix package tests in CI

### DIFF
--- a/.agents/tasks/2025/06/29-2204-nix-ci-packages
+++ b/.agents/tasks/2025/06/29-2204-nix-ci-packages
@@ -1,0 +1,1 @@
+Make sure the nix packages exposed in the flake are tested in the Nix CI run. Make sure that the nix packaging process is tested on macOS as well. The CI workflows should confirm that the nix packages are working with some basic smoke tests on each platform.

--- a/.agents/tasks/2025/06/29-2222-nix-ci-macos
+++ b/.agents/tasks/2025/06/29-2222-nix-ci-macos
@@ -1,0 +1,1 @@
+Address inline comments from previous PR, ensure Nix packages can build with buildGem function missing, test packaging on macOS, run smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,11 @@ jobs:
             }
 
   nix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -135,3 +139,9 @@ jobs:
         run: nix develop -c just build-extension
       - name: Run tests via Nix
         run: nix develop -c just test
+      - name: Build Nix packages
+        run: |
+          nix build .#codetracer-ruby-recorder -o result-ruby
+          ./result-ruby/bin/codetracer-ruby-recorder --help >/dev/null
+          nix build .#codetracer-pure-ruby-recorder -o result-pure
+          ./result-pure/bin/codetracer-pure-ruby-recorder --help >/dev/null

--- a/flake.nix
+++ b/flake.nix
@@ -91,10 +91,11 @@
 
     packages = forEachSystem (system: let
       pkgs = import nixpkgs { inherit system; };
-      buildGem = gemdir: pkgs.rubyPackages.buildRubyGem {
-        pname = builtins.baseNameOf gemdir;
+      buildGem = gemdir: pkgs.buildRubyGem {
+        gemName = builtins.baseNameOf gemdir;
         version = builtins.readFile ./version.txt;
-        src = gemdir;
+        src = ./.;
+        sourceRoot = gemdir;
       };
     in {
       codetracer-ruby-recorder = buildGem ./gems/codetracer-ruby-recorder;


### PR DESCRIPTION
## Summary
- run Nix workflow on Linux and macOS
- build flake packages and run simple `--help` checks

## Testing
- `just build-extension`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6861b7ba63288329b123e8de5105e3b4