### PR TITLE
Fix Windows build step

### DIFF
--- a/.agents/tasks/2025/06/29-2122-check-windows-ci
+++ b/.agents/tasks/2025/06/29-2122-check-windows-ci
@@ -1,0 +1,1 @@
+Navigate to GitHub CI runs and examine Windows failures, guess issue and propose fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
             ./vcpkg install capnproto:x64-windows
             echo "VCPKG_ROOT=$(pwd)" >> $GITHUB_ENV
             echo "CMAKE_TOOLCHAIN_FILE=$(pwd)/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
+            echo "$(pwd)/installed/x64-windows/tools/capnproto" >> $GITHUB_PATH
             cd ..
           fi
       - name: Setup Ruby


### PR DESCRIPTION
## Summary
- add capnproto tool path on Windows during CI setup

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6861ae43cb108329b73a4f7e40be8a04