### PR TITLE
Optimize native tracer parameter handling

### DIFF
--- a/.agents/tasks/2025/06/29-2223-optimize-native-tracer
+++ b/.agents/tasks/2025/06/29-2223-optimize-native-tracer
@@ -1,0 +1,1 @@
+Read the code of the native tracer implementation line by line and improve performance while preserving correctness


### PR DESCRIPTION
## Summary
- avoid path string allocations when recording events
- compute parameter values once and reuse to register variables
- pass event content as `String` to avoid copies

## Testing
- `just build-extension`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6861bc81de708329ac20c4107a7b687c