### PR TITLE
Optimize native tracer performance

### DIFF
--- a/.agents/tasks/2025/06/29-2223-improve-native-tracer-performance
+++ b/.agents/tasks/2025/06/29-2223-improve-native-tracer-performance
@@ -1,0 +1,1 @@
+Read the code of the native tracer implementation line by line and identify any inefficiency, improve performance while preserving correctness.


### PR DESCRIPTION
## Summary
- cache common `TypeId` values in `Recorder`
- lazily assign the `Float` type id
- centralize path filtering in a helper
- use cached ids when converting Ruby values

## Testing
- `just build-extension`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6861bc81de708329ac20c4107a7b687c