### PR TITLE
Fix ignore list path for pure Ruby tracer

### DIFF
--- a/.agents/tasks/2025/06/29-2255-fix-recorder-name
+++ b/.agents/tasks/2025/06/29-2255-fix-recorder-name
@@ -1,0 +1,1 @@
+File: gems/codetracer-pure-ruby-recorder/lib/codetracer_pure_ruby_recorder.rb, Replace codetracer_pure_ruby_recoreder.rb with codetracer_pure_ruby_recorder.rb. Ensure the tracer's ignore list skips its own file when run from this repository or when packaged.

--- a/gems/codetracer-pure-ruby-recorder/lib/codetracer_pure_ruby_recorder.rb
+++ b/gems/codetracer-pure-ruby-recorder/lib/codetracer_pure_ruby_recorder.rb
@@ -46,7 +46,8 @@ module CodeTracer
 
       tracer.record.register_call('', 1, '<top-level>', [])
       tracer.ignore('lib/ruby')
-      tracer.ignore('codetracer_pure_ruby_recoreder.rb')
+      tracer.ignore('codetracer_pure_ruby_recorder.rb')
+      tracer.ignore(File.expand_path(__FILE__))
       tracer.ignore('recorder.rb')
       tracer.ignore('<internal:')
       tracer.ignore('gems/')


### PR DESCRIPTION
## Summary
- ignore the Ruby tracer file name and absolute path so the tracer doesn't record itself

## Testing
- `just build-extension`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6861c3fe20c083298a52416305d36717