### PR TITLE
Update rb_raise error handling

### DIFF
--- a/.agents/tasks/2025/06/29-2309-cstring-error
+++ b/.agents/tasks/2025/06/29-2309-cstring-error
@@ -1,0 +1,1 @@
+Create CString objects for error strings before passing them to rb_raise


### PR DESCRIPTION
## Summary
- ensure CString lifetimes when raising errors in native_tracer

## Testing
- `just build-extension`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6861c72d002c8329adad1d90075da58b