### PR TITLE
Update selective tracing example

### DIFF
--- a/.agents/tasks/2025/06/29-2310-update-selective-tracing
+++ b/.agents/tasks/2025/06/29-2310-update-selective-tracing
@@ -1,0 +1,1 @@
+Update example selective_tracing.rb to require codetracer_ruby_recorder after computing ext_base, replace enable_tracing/disable_tracing with start/stop, confirm example runs

--- a/examples/selective_tracing.rb
+++ b/examples/selective_tracing.rb
@@ -1,15 +1,16 @@
 #!/usr/bin/env ruby
 
-ext_base = File.expand_path('../gems/codetracer-ruby-recorder/ext/native_tracer/target/release/libcodetracer_ruby_recorder', __dir__)
-require ext_base
+ext_base = File.expand_path('../gems/codetracer-ruby-recorder/lib', __dir__)
+$LOAD_PATH.unshift(ext_base) unless $LOAD_PATH.include?(ext_base)
+require 'codetracer_ruby_recorder'
 
 recorder = CodeTracer::RubyRecorder.new
 
 puts 'start trace'
-recorder.disable_tracing
+recorder.stop
 puts 'this will not be traced'
-recorder.enable_tracing
+recorder.start
 puts 'this will be traced'
-recorder.disable_tracing
+recorder.stop
 puts 'tracing disabled'
 recorder.flush_trace(Dir.pwd)


### PR DESCRIPTION
## Summary
- load the ruby recorder gem in `examples/selective_tracing.rb`
- switch example to use `start`/`stop` recorder control methods

## Testing
- `just test`
- `ruby examples/selective_tracing.rb`

------
https://chatgpt.com/codex/tasks/task_e_6861c76bbe3483298a889146beb0bf95