### PR TITLE
Fix extension build on gem install

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -4,3 +4,7 @@ The native tracer (Rust extension) caches frequently used Ruby method IDs and
 class constants in the `Recorder` struct. When adding new Ruby method calls,
 ensure the IDs are interned once during allocation and stored in the struct for
 reuse.
+
+When the native extension is built via `rb_sys` during gem installation, the
+compiled shared library is placed directly under the gem's `lib` directory
+instead of `ext/native_tracer/target/release`.

--- a/.agents/tasks/2025/06/29-2312-fix-extension-spec
+++ b/.agents/tasks/2025/06/29-2312-fix-extension-spec
@@ -1,0 +1,1 @@
+In codetracer-ruby-recorder.gemspec, set spec.extensions to ['ext/native_tracer/extconf.rb'] and verify that rake build produces a gem that compiles the extension when installed

--- a/gems/codetracer-ruby-recorder/codetracer-ruby-recorder.gemspec
+++ b/gems/codetracer-ruby-recorder/codetracer-ruby-recorder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     'ext/native_tracer/target/release/*'
   ]
   spec.require_paths = ['lib']
-  spec.extensions    = []
+  spec.extensions    = ['ext/native_tracer/extconf.rb']
   spec.bindir        = 'bin'
   spec.executables   = ['codetracer-ruby-recorder']
 

--- a/gems/codetracer-ruby-recorder/lib/codetracer_ruby_recorder.rb
+++ b/gems/codetracer-ruby-recorder/lib/codetracer_ruby_recorder.rb
@@ -117,6 +117,14 @@ module CodeTracer
         ext_dir = File.expand_path('../ext/native_tracer/target/release', __dir__)
         dlext = RbConfig::CONFIG['DLEXT']
         target_path = File.join(ext_dir, "codetracer_ruby_recorder.#{dlext}")
+
+        unless File.exist?(target_path)
+          # When built via rb_sys during gem installation, the extension is
+          # placed directly under the gem's lib directory.
+          lib_path = File.expand_path("codetracer_ruby_recorder.#{dlext}", __dir__)
+          target_path = lib_path if File.exist?(lib_path)
+        end
+
         unless File.exist?(target_path)
           extensions = %w[so bundle dylib dll]
           alt_path = extensions


### PR DESCRIPTION
## Summary
- build the native extension during gem installation
- look for compiled extension in `lib`
- document extension location when built with rb_sys

## Testing
- `just build-extension`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6861c8055be08329ac90df95ec6e8a3f