### PR TITLE
ci: install msys2 toolchain on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
             # Install MSYS2 and required packages
             choco install msys2 -y
-            C:/msys64/usr/bin/bash -lc "pacman -S --noconfirm mingw-w64-x86_64-clang capnproto"
+            C:/msys64/usr/bin/bash -lc "pacman -S --noconfirm mingw-w64-x86_64-clang mingw-w64-x86_64-capnproto"
             # Ensure MSYS2 toolchain is used for builds
             echo 'C:\msys64\mingw64\bin' >> $GITHUB_PATH
             echo 'LIBCLANG_PATH=C:\msys64\mingw64\lib' >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- install MSYS2/MinGW and capnproto on Windows runners
- drop LLVM and vcpkg setup
- add msys64 bin directory to PATH and export clang variables

## Testing
- `just build-extension`
- `just test` *(fails: Content for p mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6890b1451acc8323bf286afe8736a918