### PR TITLE
Fix PATH handling in gem installation tests

### DIFF
--- a/test/gem_installation.rb
+++ b/test/gem_installation.rb
@@ -22,7 +22,12 @@ class GemInstallationTest < Minitest::Test
         gem_file = gem_build.lines.grep(/File:/).first.split.last
         gem_file = File.expand_path(File.join(gem_dir, gem_file))
 
-        env = { 'GEM_HOME' => gem_home, 'GEM_PATH' => gem_home, 'PATH' => "#{gem_home}/bin:#{ENV['PATH']}" }
+        path_separator = File::PATH_SEPARATOR
+        env = {
+          'GEM_HOME' => gem_home,
+          'GEM_PATH' => gem_home,
+          'PATH' => "#{gem_home}/bin#{path_separator}#{ENV['PATH']}"
+        }
         system(env, 'gem', 'install', '--local', gem_file, exception: true)
 
         out_dir = File.join('test', 'tmp', "gem_install_#{gem_bin.tr('-', '_')}")


### PR DESCRIPTION
## Summary
- use the platform `PATH` separator when invoking installed gems

## Testing
- `just test` *(fails: TestKernelPatches#test_correct_event_arguments, TraceTest#test_more_types)*

------
https://chatgpt.com/codex/tasks/task_e_689af0ea841c832387d41029d23cb63c