### PR TITLE
feat: Add --version flag, sibling-pins, and bump-version recipe

### DIFF
--- a/.github/sibling-pins.json
+++ b/.github/sibling-pins.json
@@ -1,0 +1,4 @@
+{
+  "codetracer": "main",
+  "codetracer-trace-format": "main"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.json
 !.devcontainer/devcontainer.json
+!.github/sibling-pins.json
 !test/fixtures/*.json
 !test/benchmarks/fixtures/*.json
 test/tmp/

--- a/Justfile
+++ b/Justfile
@@ -46,3 +46,8 @@ lint:
     just lint-nix
 
 alias fmt := format
+
+# Bump version in version.txt (usage: just bump-version 0.2.0)
+bump-version version:
+    echo "{{version}}" > version.txt
+    @echo "version.txt → {{version}}"

--- a/gems/codetracer-ruby-recorder/lib/codetracer_ruby_recorder.rb
+++ b/gems/codetracer-ruby-recorder/lib/codetracer_ruby_recorder.rb
@@ -22,6 +22,12 @@ module CodeTracer
           puts opts
           exit
         end
+        opts.on('-V', '--version', 'Print version and exit') do
+          version_file = File.join(__dir__, '..', '..', 'version.txt')
+          version = File.exist?(version_file) ? File.read(version_file).strip : 'unknown'
+          puts "codetracer-ruby-recorder #{version}"
+          exit
+        end
       end
       parser.order!(argv)
 


### PR DESCRIPTION
## Summary
- Add `--version`/`-V` flag to the CLI that reads version from `version.txt`
- Add `.github/sibling-pins.json` for cross-repo CI coordination
- Add `bump-version` recipe to Justfile
- Update `.gitignore` to allow `.github/sibling-pins.json`

Part of the effort to align all recorder repos with the conventions defined in `codetracer-specs/Repo-Requirements.md`.

## Test plan
- [ ] `just test` passes
- [ ] `just lint` passes
- [ ] `codetracer-ruby-recorder --version` prints `codetracer-ruby-recorder 0.1.0`
- [ ] `just bump-version 0.2.0` updates `version.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)