### PR TITLE
Add .github/copilot-instructions.md symlink

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md


### PR DESCRIPTION
## Summary
- Add `.github/copilot-instructions.md` symlink → `../AGENTS.md` (for GitHub Copilot)

The repo already has `AGENTS.md` + `CLAUDE.md` symlink. This adds the Copilot-specific path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)