### PR TITLE
Add mkRubyRecorderPackage Nix builder

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,99 @@
       file = ./rust-toolchain.toml;
       sha256 = "sha256-Qxt8XAuaUR2OMdKbN4u8dBJOhSHxS+uS06Wl9+flVEk=";
     };
+
+    # Helper function to build the native Ruby recorder for a given pkgs and Ruby.
+    # Consumers can call this with their own nixpkgs and Ruby version to ensure
+    # ABI compatibility (the native .so must match the Ruby that loads it).
+    mkRubyRecorderPackage = pkgs: ruby: let
+      inherit (pkgs) stdenv lib;
+      isLinux = stdenv.isLinux;
+    in stdenv.mkDerivation {
+      pname = "ruby-recorder-native";
+      version = builtins.readFile ./version.txt;
+
+      src = ./.;
+
+      nativeBuildInputs = [
+        pkgs.rustc
+        pkgs.cargo
+        pkgs.rustPlatform.cargoSetupHook
+        ruby              # build.rs runs `ruby` to discover RbConfig paths
+        pkgs.pkg-config
+        pkgs.capnproto     # codetracer_trace_format_capnp build.rs needs capnp
+        pkgs.llvmPackages.libclang  # bindgen (used by rb-sys) needs libclang
+      ] ++ lib.optionals stdenv.isDarwin [
+        pkgs.libiconv
+        pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+        pkgs.darwin.apple_sdk.frameworks.Security
+      ];
+
+      buildInputs = [ ruby ];
+
+      # bindgen needs LIBCLANG_PATH to find libclang.so
+      LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
+      # bindgen also needs C standard headers (stdio.h, stddef.h, etc.)
+      BINDGEN_EXTRA_CLANG_ARGS = lib.optionalString isLinux (
+        builtins.concatStringsSep " " [
+          "-isystem ${stdenv.cc.libc.dev}/include"
+          "-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/${lib.versions.major pkgs.llvmPackages.libclang.version}/include"
+        ]
+      );
+
+      cargoDeps = pkgs.rustPlatform.importCargoLock {
+        lockFile = ./gems/codetracer-ruby-recorder/ext/native_tracer/Cargo.lock;
+      };
+
+      postUnpack = ''
+        # cargoSetupHook expects Cargo.lock at the source root
+        cp $sourceRoot/gems/codetracer-ruby-recorder/ext/native_tracer/Cargo.lock \
+           $sourceRoot/Cargo.lock
+      '';
+
+      preBuild = ''
+        cd gems/codetracer-ruby-recorder/ext/native_tracer
+      '';
+
+      buildPhase = ''
+        runHook preBuild
+        cargo build --release --offline
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        GEM_ROOT="$NIX_BUILD_TOP/$sourceRoot/gems/codetracer-ruby-recorder"
+
+        # Preserve gems/ path component — the native recorder's should_ignore_path()
+        # in Rust uses "gems/" as an ignore pattern to avoid tracing kernel_patches.rb.
+        mkdir -p $out/gems/bin $out/gems/lib/codetracer $out/gems/ext/native_tracer/target/release
+
+        # Copy compiled .so (Rust cdylib produces lib<name>.so on Linux, lib<name>.dylib on macOS)
+        local dlext="${if isLinux then "so" else "dylib"}"
+        cp target/release/libcodetracer_ruby_recorder.$dlext \
+           $out/gems/ext/native_tracer/target/release/
+        # Create the name the Ruby wrapper expects (codetracer_ruby_recorder.<dlext>)
+        ln -s libcodetracer_ruby_recorder.$dlext \
+           $out/gems/ext/native_tracer/target/release/codetracer_ruby_recorder.$dlext
+
+        # Copy Ruby wrapper files
+        cp "$GEM_ROOT/lib/codetracer_ruby_recorder.rb" $out/gems/lib/
+        cp "$GEM_ROOT/lib/codetracer/kernel_patches.rb" $out/gems/lib/codetracer/
+
+        # Copy bin entry script
+        cp "$GEM_ROOT/bin/codetracer-ruby-recorder" $out/gems/bin/
+
+        # Top-level bin/ symlink so consumers' symlinkJoin picks it up
+        mkdir -p $out/bin
+        ln -s $out/gems/bin/codetracer-ruby-recorder $out/bin/codetracer-ruby-recorder
+      '';
+
+      doCheck = false;
+    };
   in {
+    # Expose the helper function for consumers who need a custom Ruby version
+    lib.mkRubyRecorderPackage = mkRubyRecorderPackage;
+
     checks = forEachSystem (system: {
       pre-commit-check = pre-commit-hooks.lib.${system}.run {
         src = ./.;
@@ -104,15 +196,26 @@
 
     packages = forEachSystem (system: let
       pkgs = import nixpkgs { inherit system; };
-      buildGem = gemdir: pkgs.rubyPackages.buildRubyGem {
-        pname = builtins.baseNameOf gemdir;
-        version = builtins.readFile ./version.txt;
-        src = gemdir;
-      };
+      ruby = pkgs.ruby;
     in {
-      codetracer-ruby-recorder = buildGem ./gems/codetracer-ruby-recorder;
-      codetracer-pure-ruby-recorder = buildGem ./gems/codetracer-pure-ruby-recorder;
+      # Native Rust extension-based recorder (default)
+      codetracer-ruby-recorder = mkRubyRecorderPackage pkgs ruby;
       default = self.packages.${system}.codetracer-ruby-recorder;
+
+      # Pure Ruby recorder (fallback, no compilation needed)
+      codetracer-pure-ruby-recorder = pkgs.stdenv.mkDerivation {
+        pname = "ruby-recorder-pure";
+        version = builtins.readFile ./version.txt;
+        src = ./.;
+        dontInstall = true;
+        buildPhase = ''
+          mkdir -p $out/gems/bin $out/gems/lib
+          cp -Lr ./gems/codetracer-pure-ruby-recorder/bin/codetracer-pure-ruby-recorder $out/gems/bin/
+          cp -Lr ./gems/codetracer-pure-ruby-recorder/lib/* $out/gems/lib/
+          mkdir -p $out/bin
+          ln -s $out/gems/bin/codetracer-pure-ruby-recorder $out/bin/codetracer-pure-ruby-recorder
+        '';
+      };
     });
   };
 }


### PR DESCRIPTION
## Summary
- Introduce a reusable `mkRubyRecorderPackage` helper in `flake.nix` that builds the native Rust-based Ruby recorder as a proper Nix derivation, replacing the previous `buildRubyGem` approach which could not handle Rust/Cargo compilation
- Wire up all required build dependencies (cargo, bindgen via LIBCLANG_PATH, capnproto) and preserve the `gems/` directory layout so runtime ignore patterns work correctly
- Expose `lib.mkRubyRecorderPackage` for downstream consumers who need to build against a custom Ruby version for ABI compatibility

## Test plan
- [ ] `nix build .#codetracer-ruby-recorder` succeeds on Linux
- [ ] `nix build .#codetracer-pure-ruby-recorder` succeeds
- [ ] The built recorder binary works end-to-end with CodeTracer
- [ ] Downstream consumers can call `mkRubyRecorderPackage` with a custom Ruby

🤖 Generated with [Claude Code](https://claude.com/claude-code)