### PR TITLE
ci: rename runner label nixos-equivalent -> dev-env-ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             runs-on: [self-hosted, aarch64-darwin]
             flavor: nix
           - label: windows
-            runs-on: [self-hosted, Windows, X64, nixos-equivalent]
+            runs-on: [self-hosted, Windows, X64, dev-env-ready]
             flavor: windows-diy
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Renames the persistent Windows runner capability label this repo selects on:
`nixos-equivalent` -> `dev-env-ready`. `nixos-equivalent` is a nonsensical name
for a Windows box.

### This is safe to merge now

Phase 1 of the migration is already done and live. Both persistent Windows
runners advertise **both** labels today:

```
37586 win-ci-vm-001    online  [self-hosted, X64, Windows, nixos-equivalent, dev-env-ready]
41953 win-ci-bare-001  online  [self-hosted, X64, Windows, nixos-equivalent, dev-env-ready]
```

The pair is also baked into `register-runner.ps1`, `services/github-runners/{common,windows}.nix`
and both hosts' `meta.nix` in `metacraft-labs/infra`, so a re-registration or a
fresh bring-up reproduces it. So this PR changes which of two equivalent names
is used; it does not change which machines can pick the job up.

### Why the ordering matters

A `runs-on` label that matches no runner does **not** fail the job — GitHub
queues it forever, with no error and no timeout. That is why the new label was
added to the runners first, why the old one is still advertised, and why
`nixos-equivalent` will only be removed from the runners after every consumer
PR in this series has merged.

### Not addressed here

The label's *meaning* is unchanged, and it is worth knowing that the capability
claim behind it is currently false on `win-ci-bare-001`: `common.nix` defines it
as "offering a developer-grade environment via `codetracer/env.ps1`", and that
checkout does not exist on that host. Renaming does not fix that; it is tracked
separately.

Part of an org-wide series. Nothing else in this repo is touched.
