### PR TITLE
ci: repin metacraft-github-actions actions from @main to @dev

### DIFF
--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -64,7 +64,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env (reprobuild flavor)
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: reprobuild
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -103,7 +103,7 @@ jobs:
       - name: Mirror test logs to S3 (non-blocking)
         if: failure()
         continue-on-error: true
-        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@dev
         with:
           path: target/
           prefix: reprobuild-logs-${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}/target
@@ -116,7 +116,7 @@ jobs:
       - name: Mirror reprobuild logs to S3 (non-blocking)
         if: failure()
         continue-on-error: true
-        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@dev
         with:
           path: .repro/
           prefix: reprobuild-logs-${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}/repro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: ${{ matrix.flavor }}
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -87,7 +87,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -163,7 +163,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/launcher-integration.yml
+++ b/.github/workflows/launcher-integration.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           path: codetracer-ruby-recorder
 
-      - uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+      - uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-launcher
           ref: main


### PR DESCRIPTION
After the org-wide `main`->`dev` rename of `metacraft-labs/metacraft-github-actions`, its old `main` branch no longer resolves for GitHub Actions (`git/ref/heads/main` 404s; `@main` fails at action-load). This repins every `uses: metacraft-labs/metacraft-github-actions/<action>@main` here to `@dev` (the new mainline).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>