### PR TITLE
Let a recorded Ruby program declare where its values cross boundaries

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -55,3 +55,22 @@ RS-M6 (request spans) — two more things that cost real time:
   CodeTracer middleware live, so an eight-request Sinatra session is ~750 steps
   in three files. (The Python recorder needed a whole `trace_filter.toml` for
   the same milestone.)
+
+Correlation markers — the shape to copy, and the one trap:
+
+* The Ruby facade never calls `to_s`. `CodeTracer::Native.mark_correlation_send`
+  hands `key:` / `show:` to the extension UNCONVERTED, because those are the
+  traced program's own objects: converting them in Ruby would let an exploding
+  `to_s` kill a program that only annotated itself. The extension renders them
+  with `value_to_string_exception_safe`, before the tracer lock, which is also
+  what lets a NUL-containing key through instead of raising.
+  (`register_span`'s `metadata` DOES call `to_s` in Ruby — those are the
+  middleware's own strings, not user values. The asymmetry is deliberate.)
+* Nothing here decides what a marker IS. The `MarkerPayload`, the label
+  interning table and the `corrmark.ns` index are built once in the shared
+  writer library so ~20 recorders cannot drift; a drifted payload would produce
+  markers that are INVISIBLE rather than broken. Do not add a label cache to
+  this repo — hoist `ensure_marker_id` at the call site and pass `marker_id:`.
+* `ct print --json-events` does NOT carry the IO metadata slot, so it cannot see
+  markers. `ct print --markers --json-out` is the view that decodes them;
+  `test/ct_print_support.rb#ct_print_markers` wraps it.

--- a/gems/codetracer-ruby-recorder/ext/native_tracer/src/lib.rs
+++ b/gems/codetracer-ruby-recorder/ext/native_tracer/src/lib.rs
@@ -1570,6 +1570,258 @@ unsafe extern "C" fn register_span_api(self_val: VALUE, spec: VALUE) -> VALUE {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Correlation markers
+// ---------------------------------------------------------------------------
+//
+// A *correlation marker* declares that a value crossed a boundary — a queue, a
+// socket, an IPC channel — so a debugger can pair the `send` side with the
+// `recv` side and a consumer can ask "does this recording cover span X?"
+// without decoding the event stream.  Spec:
+// `codetracer-specs/Testing/CTFS-Correlation-Marker-Contract.md` §§10, 11a and
+// `codetracer-specs/GUI/Debugging-Features/Correlation-Markers.md` §2.4.
+//
+// **Nothing about what a marker IS lives here.**  The `MarkerPayload` document,
+// the label-interning table and the `corrmark.ns` index are built once, in the
+// shared writer library, precisely so that ~20 CTFS recorders cannot drift into
+// writing payloads that are *unreadable* rather than merely degraded (§11a).
+// These entry points marshal arguments and nothing else.
+//
+// Three properties are load-bearing and are the reason this code is shaped like
+// `register_span_api` rather than like the obvious thing:
+//
+// * **No step is minted** (§11a.6).  The marker attaches to the enclosing step.
+//   That is the writer's behaviour, not ours — we simply do not call
+//   `register_step` — and `test/test_correlation_markers.rb` pins it by
+//   recording the same program with and without markers and comparing step
+//   counts.
+// * **Every Ruby value is stringified BEFORE the tracer lock is taken**
+//   (§11a.5).  `key:` is whatever the traced program passed, so rendering it is
+//   arbitrary user code: it may raise — which with a live `MutexGuard` wedges
+//   the process forever (see the `tracer_lock` module docs) — and it may execute
+//   traced lines, which would re-enter the event hook and self-deadlock on the
+//   non-reentrant lock.  `in_event_hook` closes the second door while the
+//   conversions run and is restored on EVERY path.
+// * **Pointer + length, never a C string** (§11a.5).  A Ruby String may legally
+//   contain a NUL byte and `rb_string_value_cstr` RAISES on one — a known wedge.
+//   `value_to_string_exception_safe` reads the string's buffer directly, and the
+//   shared library's entry points take a length, so the byte survives into the
+//   payload (as ` `) instead of truncating the key or hanging the process.
+
+/// A Ruby Integer as a `u64`, or `None` when it is absent or Ruby refused.
+///
+/// `rb_num2ull` RAISES — `RangeError` for a negative or oversized Integer,
+/// `TypeError` for a non-numeric — and a raise here `longjmp`s straight out of
+/// the entry point, skipping the `in_event_hook` restore and leaving the
+/// recorder permanently convinced it is inside a hook (i.e. silently deaf).
+/// [`protect`] turns that into a `None` the caller can default.
+unsafe fn ruby_integer_to_u64(val: VALUE) -> Option<u64> {
+    if NIL_P(val) {
+        return None;
+    }
+    protect(|| rb_num2ull(val) as u64).ok()
+}
+
+/// The marshalled form of a `mark_correlation` spec Hash.
+///
+/// Every field is an owned Rust `String` by the time this exists, which is the
+/// point: it is constructed OUTSIDE the tracer lock and used inside it, so no
+/// Ruby code can run while the writer is held.
+struct MarkerSpec {
+    direction: String,
+    boundary: String,
+    key_value: String,
+    show_value: String,
+    description: String,
+    key_text: String,
+    show_text: String,
+    /// A previously interned label id.  `Some` selects the by-id path, which
+    /// is the primary one (§11a.4): a caller hoists `ensure_marker_id` out of
+    /// its hot path so the per-crossing call does no string lookup.
+    marker_id: Option<u64>,
+}
+
+/// Intern a correlation-marker boundary label and return its id.
+///
+/// Returns the id as an Integer, or `nil` when it could not be interned —
+/// because the writer refused, or because Ruby raised while rendering `label`.
+/// `nil` rather than an exception on purpose: a marker is an annotation a
+/// program makes about itself, and a recorder that aborted the traced program
+/// because it could not annotate it would be worse than one that recorded
+/// nothing.  The caller's fallback is the string-label path, which costs a
+/// lookup per crossing but still writes a correct marker.
+unsafe extern "C" fn ensure_marker_id_api(self_val: VALUE, label: VALUE) -> VALUE {
+    let recorder = &mut *get_recorder(self_val);
+
+    let was_in_hook = recorder.data.in_event_hook;
+    recorder.data.in_event_hook = true;
+
+    // Rendered before the lock — `label` may be any object, so `to_s` here is
+    // arbitrary user code.
+    let label_string = value_to_string_exception_safe(&recorder.data, label);
+    let interned = recorder
+        .tracer
+        .with(|tracer| TraceWriter::ensure_marker_id(tracer, &label_string));
+
+    recorder.data.in_event_hook = was_in_hook;
+
+    match interned {
+        Ok(Ok(id)) => rb_ull2inum(id),
+        Ok(Err(e)) => {
+            if debug_enabled() {
+                eprintln!("codetracer-ruby-recorder: could not intern marker label: {e}");
+            }
+            Qnil.into()
+        }
+        Err(RubyRaised) => Qnil.into(),
+    }
+}
+
+/// Declare that a value crossed a boundary.
+///
+/// `spec` is a Hash with symbol keys — `direction`, `boundary`, `key_value`,
+/// and optionally `show_value`, `description`, `key_text`, `show_text` and
+/// `marker_id`; `CodeTracer::Native` owns the public spelling and the defaults.
+///
+/// Returns `true` when the marker was recorded and `false` when the writer
+/// refused it or Ruby raised while rendering one of the values.  It does NOT
+/// raise, for the reason given on [`ensure_marker_id_api`]: this call sits in
+/// the traced program's own control flow, unlike `register_span`, which a
+/// middleware makes on the program's behalf.  A refusal is reported on stderr
+/// under `CODETRACER_RUBY_RECORDER_DEBUG`, so a `false` is diagnosable rather
+/// than merely silent.
+///
+/// A non-Hash argument DOES raise: that is a caller mistake, not a recording
+/// failure, and it can only be reached by bypassing the facade.
+unsafe extern "C" fn mark_correlation_api(self_val: VALUE, spec: VALUE) -> VALUE {
+    let recorder = &mut *get_recorder(self_val);
+
+    if !RB_TYPE_P(spec, rb_sys::ruby_value_type::RUBY_T_HASH) {
+        raise_io_error("mark_correlation expects a Hash with symbol keys");
+    }
+
+    let was_in_hook = recorder.data.in_event_hook;
+    recorder.data.in_event_hook = true;
+
+    // The whole extraction runs under one `protect`, not just the individual
+    // `to_s` dispatches: `rb_hash_aref` itself can execute Ruby (a Hash with a
+    // `default_proc`), so "the conversions cannot escape" has to be a property
+    // of the block rather than of each site in it.
+    let data = &recorder.data;
+    let marshalled = protect(|| MarkerSpec {
+        direction: spec_string(data, spec, "direction"),
+        boundary: spec_string(data, spec, "boundary"),
+        key_value: spec_string(data, spec, "key_value"),
+        show_value: spec_string(data, spec, "show_value"),
+        description: spec_string(data, spec, "description"),
+        key_text: spec_string(data, spec, "key_text"),
+        show_text: spec_string(data, spec, "show_text"),
+        marker_id: ruby_integer_to_u64(spec_value(spec, "marker_id")),
+    });
+
+    let outcome = match marshalled {
+        Err(RubyRaised) => Err(RubyRaised),
+        Ok(marker) => recorder.tracer.with(|tracer| match marker.marker_id {
+            // The by-id path still carries the label, because the on-disk
+            // payload spells `boundary_id` as text for the debugger while the
+            // index keys on the id.
+            Some(id) => TraceWriter::mark_correlation_by_id(
+                tracer,
+                id,
+                &marker.boundary,
+                &marker.direction,
+                &marker.key_value,
+                &marker.show_value,
+                &marker.description,
+                &marker.key_text,
+                &marker.show_text,
+            ),
+            None => TraceWriter::mark_correlation(
+                tracer,
+                &marker.direction,
+                &marker.boundary,
+                &marker.key_value,
+                &marker.show_value,
+                &marker.description,
+                &marker.key_text,
+                &marker.show_text,
+            ),
+        }),
+    };
+
+    // Restored before anything can leave this function, on every path.
+    recorder.data.in_event_hook = was_in_hook;
+
+    match outcome {
+        Ok(Ok(())) => Qtrue.into(),
+        Ok(Err(e)) => {
+            if debug_enabled() {
+                eprintln!("codetracer-ruby-recorder: could not record correlation marker: {e}");
+            }
+            Qfalse.into()
+        }
+        Err(RubyRaised) => {
+            if debug_enabled() {
+                eprintln!(
+                    "codetracer-ruby-recorder: correlation marker abandoned — a Ruby exception \
+                     was raised while rendering its values"
+                );
+            }
+            Qfalse.into()
+        }
+    }
+}
+
+/// Declare that this recording covers a distributed-trace span.
+///
+/// The ids arrive as lowercase-or-uppercase hex (32 characters for `trace_id`,
+/// 16 for `span_id`) because that is what every OTel API hands a Ruby program.
+/// The hex→bytes conversion is done by the SHARED library, not here: the
+/// correlation index keys on the wire bytes, so a recorder that hashed the hex
+/// rendering instead would build an index that is present, correct-looking, and
+/// permanently unqueryable — the exact silent-failure class this whole contract
+/// exists to remove.
+///
+/// Returns `true` on success and `false` when the writer refused the marker or
+/// the ids were not valid hex; see [`mark_correlation_api`] for why it does not
+/// raise.
+unsafe extern "C" fn mark_span_coverage_api(
+    self_val: VALUE,
+    trace_id_hex: VALUE,
+    span_id_hex: VALUE,
+    wall_time_unix_ns: VALUE,
+    monotonic_time_ns: VALUE,
+) -> VALUE {
+    let recorder = &mut *get_recorder(self_val);
+
+    let was_in_hook = recorder.data.in_event_hook;
+    recorder.data.in_event_hook = true;
+
+    // Same rule as everywhere else on this path: every Ruby->Rust conversion
+    // finishes before the tracer lock is taken.
+    let trace_id = value_to_string_exception_safe(&recorder.data, trace_id_hex);
+    let span_id = value_to_string_exception_safe(&recorder.data, span_id_hex);
+    let wall = ruby_integer_to_u64(wall_time_unix_ns).unwrap_or(0);
+    let monotonic = ruby_integer_to_u64(monotonic_time_ns).unwrap_or(0);
+
+    let outcome = recorder.tracer.with(|tracer| {
+        TraceWriter::mark_span_coverage_hex(tracer, &trace_id, &span_id, wall, monotonic)
+    });
+
+    recorder.data.in_event_hook = was_in_hook;
+
+    match outcome {
+        Ok(Ok(())) => Qtrue.into(),
+        Ok(Err(e)) => {
+            if debug_enabled() {
+                eprintln!("codetracer-ruby-recorder: could not record span coverage: {e}");
+            }
+            Qfalse.into()
+        }
+        Err(RubyRaised) => Qfalse.into(),
+    }
+}
+
 /// Decode the span stream of the `.ct` container at `path` into JSON.
 ///
 /// The READ counterpart of [`register_span_api`], present so this recorder's own
@@ -1671,6 +1923,28 @@ pub extern "C" fn Init_codetracer_ruby_recorder() {
             c"current_thread_id".as_ptr() as *const c_char,
             ruby_method(current_thread_id as *const ()),
             0,
+        );
+        // Correlation markers.  See the section above; `CodeTracer::Native`
+        // is the process-wide facade over these, and it is what user code
+        // spells (`mark_correlation_send` / `_recv`), because a traced program
+        // never sees the recorder object.
+        rb_define_method(
+            class,
+            c"ensure_marker_id".as_ptr() as *const c_char,
+            ruby_method(ensure_marker_id_api as *const ()),
+            1,
+        );
+        rb_define_method(
+            class,
+            c"mark_correlation".as_ptr() as *const c_char,
+            ruby_method(mark_correlation_api as *const ()),
+            1,
+        );
+        rb_define_method(
+            class,
+            c"mark_span_coverage".as_ptr() as *const c_char,
+            ruby_method(mark_span_coverage_api as *const ()),
+            4,
         );
         // Read side — singleton methods, because inspecting a finished
         // container is not an operation on a live recording.

--- a/gems/codetracer-ruby-recorder/lib/codetracer/native.rb
+++ b/gems/codetracer-ruby-recorder/lib/codetracer/native.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
-# RS-M6 — span emission into the recorded `.ct` container.
+# The process-wide facade over the native recorder.
+#
+# Two things live here, and they share the facade for the same reason: user code
+# never sees the recorder object, so both need a process-wide seam that is a
+# no-op when nothing is being recorded.
+#
+#   * **Spans** (RS-M6) — bounded, labeled intervals of execution, written by
+#     `CodeTracer::Rack::Middleware` in a different gem.
+#   * **Correlation markers** — boundary crossings declared by the traced
+#     program itself; see the section further down.
+#
+# ## Spans
 #
 # A *span* is a bounded, labeled interval of execution — an HTTP request, a
 # process, a test.  Since RS-M1 the trace container carries them in its own
@@ -174,6 +185,140 @@ module CodeTracer
           concurrent_with_siblings: concurrent_with_siblings,
           metadata: metadata.map { |key, value| [key.to_s, value.to_s] }
         )
+      end
+
+      # --- Correlation markers -------------------------------------------
+      #
+      # A *correlation marker* records that a value crossed a boundary — a
+      # queue, a socket, an IPC channel — so the debugger can pair the sending
+      # side with the receiving side, and so a consumer can ask "does this
+      # recording cover span X?" through the container's `corrmark.ns` index
+      # instead of decoding the event stream.
+      #
+      # Public spellings per
+      # `codetracer-specs/GUI/Debugging-Features/Correlation-Markers.md` §2.4:
+      #
+      #   CodeTracer::Native.mark_correlation_send('order-processing',
+      #                                            key: msg.id, show: msg.body,
+      #                                            desc: 'Outbound order')
+      #   # ... on the other side ...
+      #   CodeTracer::Native.mark_correlation_recv('order-processing',
+      #                                            key: envelope.id,
+      #                                            show: envelope.body)
+      #
+      # ## Three things this facade deliberately does NOT do
+      #
+      # 1. **It does not call `to_s` on anything.**  `key:` and `show:` are
+      #    whatever the traced program passed, and an object whose `to_s`
+      #    raises must not take the program down just because it was being
+      #    recorded.  The values are handed to the extension untouched and
+      #    rendered there, exception-safely, before the writer lock is taken —
+      #    which is also what keeps a NUL-containing String from wedging the
+      #    recorder.  (Contrast {register_span}'s `metadata`, whose values are
+      #    the middleware's own strings.)
+      # 2. **It does not cache boundary-label ids.**  Interning lives in the
+      #    shared writer library on purpose: a per-recorder label cache is
+      #    exactly the drift the shared API exists to prevent
+      #    (`CTFS-Correlation-Marker-Contract.md` §11a.4).  A caller with a hot
+      #    boundary hoists {ensure_marker_id} itself and passes `marker_id:`.
+      # 3. **It does not build the payload.**  Field names, the `corrmark.ns`
+      #    index and the send/recv defaulting are the library's, so ~20
+      #    recorders cannot fall out of step and write markers that are
+      #    *unreadable* rather than merely degraded.
+      #
+      # Every entry point returns `false` when no recording is active.  That is
+      # the no-op contract, not an error: user code calls these unconditionally
+      # and is only sometimes recorded.
+
+      # Wire values of a marker's `direction`.  Anything else is normalised to
+      # `send` by the writer, because a marker with no side is unpairable and
+      # an unpairable marker is worse than one that picked a side.
+      DIRECTION_SEND = 'send'
+      DIRECTION_RECV = 'recv'
+
+      # Intern `boundary` and return its numeric marker id, or `nil` when
+      # nothing is recording (or the writer could not intern it).
+      #
+      # THE PRIMARY OPERATION for a hot boundary: hoist this out of the loop and
+      # pass the result to {mark_correlation_send} / {mark_correlation_recv} as
+      # `marker_id:`, and the per-crossing call does no string lookup.  Callers
+      # that cross a boundary occasionally can ignore it entirely — the
+      # string-label path interns for them.
+      def ensure_marker_id(boundary)
+        recorder = @recorder
+        return nil if recorder.nil?
+
+        recorder.ensure_marker_id(boundary)
+      end
+
+      # Declare that a value LEFT this process across `boundary`.
+      #
+      # `key:` is the pairing key — the value that will be recognisable on the
+      # other side (a message id, a correlation header).  `show:` is an
+      # optional payload rendered next to the marker in the Event Log, `desc:`
+      # an optional human note.
+      #
+      # `key_text:` / `show_text:` are the NAMES those values were read under.
+      # `show_text` is load-bearing rather than cosmetic: a cross-process origin
+      # chain resumes its walk on that name in the sending recording, so a
+      # marker that drops it is visible with its history unreachable.  They
+      # default to the library's `"key"` / `"show"`.
+      #
+      # Returns `true` when the marker was recorded, `false` when nothing is
+      # recording or the writer refused it.
+      def mark_correlation_send(boundary, key:, show: nil, desc: nil,
+                                key_text: nil, show_text: nil, marker_id: nil)
+        mark_correlation(DIRECTION_SEND, boundary, key: key, show: show, desc: desc,
+                                         key_text: key_text, show_text: show_text,
+                                         marker_id: marker_id)
+      end
+
+      # Declare that a value ARRIVED in this process across `boundary`.
+      # The counterpart of {mark_correlation_send}; see it for the arguments.
+      def mark_correlation_recv(boundary, key:, show: nil, desc: nil,
+                                key_text: nil, show_text: nil, marker_id: nil)
+        mark_correlation(DIRECTION_RECV, boundary, key: key, show: show, desc: desc,
+                                         key_text: key_text, show_text: show_text,
+                                         marker_id: marker_id)
+      end
+
+      # The direction-agnostic form, for a caller that has the direction in a
+      # variable.  `direction` is {DIRECTION_SEND} or {DIRECTION_RECV}.
+      def mark_correlation(direction, boundary, key:, show: nil, desc: nil,
+                           key_text: nil, show_text: nil, marker_id: nil)
+        recorder = @recorder
+        return false if recorder.nil?
+
+        # Values go through UNCONVERTED — see the note above on why this facade
+        # never calls `to_s`.
+        recorder.mark_correlation(
+          direction: direction,
+          boundary: boundary,
+          key_value: key,
+          show_value: show,
+          description: desc,
+          key_text: key_text,
+          show_text: show_text,
+          marker_id: marker_id
+        )
+      end
+
+      # Declare that this recording covers the distributed-trace span
+      # `(trace_id, span_id)`.
+      #
+      # The ids are hex, as every OTel Ruby API hands them over: 32 characters
+      # for `trace_id`, 16 for `span_id`.  They are converted to wire bytes by
+      # the shared library, never here — the correlation index keys on those
+      # bytes, and an index keyed on a hex rendering would be present,
+      # correct-looking and permanently unqueryable.
+      #
+      # Returns `true` when the coverage marker was recorded, `false` when
+      # nothing is recording or the ids were not valid hex.
+      def mark_span_coverage(trace_id, span_id, wall_time_unix_ns, monotonic_time_ns)
+        recorder = @recorder
+        return false if recorder.nil?
+
+        recorder.mark_span_coverage(trace_id, span_id, wall_time_unix_ns, monotonic_time_ns)
       end
 
       # Decode the span stream of the `.ct` container at `path`.

--- a/test/ct_print_support.rb
+++ b/test/ct_print_support.rb
@@ -29,4 +29,24 @@ module CtPrintSupport
 
     JSON.parse(stdout.dup.force_encoding(Encoding::BINARY).scrub('?'))
   end
+
+  # Decode the correlation markers of the container at +ct_file+.
+  #
+  # `--markers --json-out` is the canonical marker view: `ct-print` reads each
+  # IO event's metadata slot, and when it holds a `MarkerPayload` it hoists
+  # `correlation_marker` (plus `boundary_id` / `direction` / `key_value`) to the
+  # top level of the event.  Going through it — rather than reading the metadata
+  # bytes here — is what makes this a real assertion: a payload whose field
+  # names had drifted would come back as an ordinary IO event and this list
+  # would simply be EMPTY, which is the failure mode the marker contract exists
+  # to make loud (a bad marker is invisible, not broken).
+  #
+  # `--json-events` deliberately does not carry the metadata slot, so it cannot
+  # be used for this.
+  def ct_print_markers(ct_file)
+    stdout, stderr, status = Open3.capture3(CT_PRINT, '--markers', '--json-out', ct_file)
+    raise "ct-print --markers failed for #{ct_file}: #{stderr}" unless status.success?
+
+    JSON.parse(stdout.dup.force_encoding(Encoding::BINARY).scrub('?'))
+  end
 end

--- a/test/test_correlation_markers.rb
+++ b/test/test_correlation_markers.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+# Correlation markers in the recorded `.ct` container.
+#
+# Spec: `codetracer-specs/Testing/CTFS-Correlation-Marker-Contract.md` §§10,
+# 11a, 11b and `codetracer-specs/GUI/Debugging-Features/Correlation-Markers.md`
+# §2.4 (the programmatic API — the ONLY record-time authoring path; the
+# comment / TOML paths are replay-time mechanisms and cannot be indexed while
+# recording).
+#
+# ## No mocks
+#
+# Every test here records a REAL Ruby program with the REAL recorder CLI in a
+# REAL subprocess, and reads the result back through the SHIPPED `ct-print`.
+# Nothing is stubbed, and in particular the markers are not read by a
+# test-local decoder: `ct print --markers` parses the `MarkerPayload` out of the
+# IO event's metadata slot exactly as the debugger's own consumer does, so a
+# writer that emitted a payload with drifted field names would show up here as
+# *zero markers* rather than as a passing test. That failure mode — a marker
+# that is invisible rather than broken — is the reason the shared writer owns
+# the payload and the reason this suite reads it through the canonical tool.
+#
+# ## The three properties pinned here
+#
+# 1. **A marker round-trips with its payload hoisted** — `correlation_marker`,
+#    and `boundary_id` / `direction` / `key_value` at the top level. `show_text`
+#    survives when the caller passes one; it is load-bearing rather than
+#    cosmetic, because a cross-process origin chain resumes its walk on that
+#    NAME in the sending recording, so a marker that dropped it would be visible
+#    with its history unreachable.
+# 2. **A marker mints NO step** (§11a.6). The marker attaches to the enclosing
+#    step. Minting one would insert an exec-stream event that no user code
+#    executed and shift every later step index — and spans' `start_step` /
+#    `end_step`, and every other step-addressed coordinate, are measured in
+#    those indices. Pinned by recording the SAME source twice and comparing
+#    step counts; see {MARKER_PROGRAM} for how the two runs are made
+#    line-for-line identical.
+# 3. **The API is a no-op when nothing is recording.** User code calls these
+#    unconditionally and is only sometimes recorded, so "not recording" must be
+#    a `false` return and never an exception or a load error.
+
+require 'minitest/autorun'
+require 'json'
+require 'fileutils'
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+
+require_relative 'ct_print_support'
+
+class CorrelationMarkersTest < Minitest::Test
+  include CtPrintSupport
+
+  ROOT = File.expand_path('..', __dir__)
+  RECORDER = File.join(ROOT, 'gems/codetracer-ruby-recorder/bin/codetracer-ruby-recorder')
+  GEM_LIB = File.join(ROOT, 'gems/codetracer-ruby-recorder/lib')
+
+  BOUNDARY = 'order-processing'
+  KEY = 'msg-42'
+  SHOW = '{"item":"widget"}'
+  DESCRIPTION = 'Outbound order'
+  # A real W3C trace-context pair (the example from the traceparent spec), used
+  # because `mark_span_coverage` validates the hex and would reject a
+  # made-up-looking id of the wrong length.
+  TRACE_ID = '0af7651916cd43dd8448eb211c80319c'
+  SPAN_ID = 'b7ad6b7169203331'
+
+  # Printed by the program as its last statement: proof it ran to completion,
+  # independently of what the recorder wrote.
+  COMPLETION_MARKER = 'PROGRAM-COMPLETED'
+
+  # The program every test in this file records.
+  #
+  # It is ONE source text used for three runs — marked, unmarked, and not
+  # recorded at all — because the step-count comparison is only meaningful if
+  # the two recorded runs execute the identical lines. Deleting the marker
+  # calls for the unmarked run would remove their LINES too, and the step counts
+  # would differ for a reason that has nothing to do with markers.
+  #
+  # So the switch is `CodeTracer::Native.uninstall`, which unbinds the facade
+  # from the live recorder without touching the event hook: the same call sites
+  # run in both recordings and take the same number of steps, but in the
+  # unmarked run the facade returns `false` before it reaches the writer. The
+  # recording itself is unaffected — the recorder object owns the hook, not the
+  # facade — which is exactly why the two runs remain comparable.
+  MARKER_PROGRAM = <<~RUBY
+    require 'codetracer/native'
+
+    CodeTracer::Native.uninstall unless ENV['CT_MARK'] == '1'
+
+    order_id = '#{KEY}'
+    body = '#{SHOW}'
+    sent = CodeTracer::Native.mark_correlation_send('#{BOUNDARY}', key: order_id,
+                                                    show: body, desc: '#{DESCRIPTION}')
+    received = CodeTracer::Native.mark_correlation_recv('#{BOUNDARY}', key: order_id,
+                                                        show: body, show_text: 'envelope')
+    covered = CodeTracer::Native.mark_span_coverage('#{TRACE_ID}', '#{SPAN_ID}',
+                                                    1_700_000_000_000_000_000, 42)
+    rejected = CodeTracer::Native.mark_span_coverage('not-hex', '#{SPAN_ID}', 0, 0)
+    puts "RESULTS sent=\#{sent} received=\#{received} covered=\#{covered} rejected=\#{rejected}"
+    puts '#{COMPLETION_MARKER}'
+  RUBY
+
+  def setup
+    @tmp_dirs = []
+  end
+
+  def teardown
+    @tmp_dirs.each { |dir| FileUtils.remove_entry(dir) if File.directory?(dir) }
+  end
+
+  # Record MARKER_PROGRAM and return `[container_path, stdout]`.
+  #
+  # `marking` selects whether the facade stays bound to the live recorder.
+  def record(name:, marking:)
+    dir = Dir.mktmpdir("codetracer-markers-#{name}-")
+    @tmp_dirs << dir
+    program = File.join(dir, 'marked.rb')
+    File.write(program, MARKER_PROGRAM)
+    out_dir = File.join(dir, 'trace')
+    FileUtils.mkdir_p(out_dir)
+
+    stdout, stderr, status = Open3.capture3(
+      { 'CT_MARK' => marking ? '1' : '0' },
+      RbConfig.ruby, RECORDER, '--out-dir', out_dir, program
+    )
+    assert_predicate status, :success?, "recorder failed:\n#{stdout}\n#{stderr}"
+    assert_includes stdout, COMPLETION_MARKER,
+                    "the traced program did not run to completion\n#{stdout}\n#{stderr}"
+
+    containers = Dir.glob(File.join(out_dir, '*.ct'))
+    refute_empty containers, "no .ct container was written\n#{stdout}\n#{stderr}"
+    [containers.first, stdout]
+  end
+
+  def step_count(container)
+    ct_print_events(container).count { |event| event['type'] == 'step' }
+  end
+
+  # The declared marker survives the container round-trip with its payload
+  # decodable — which is what makes it findable at all.
+  def test_declared_markers_round_trip_through_ct_print
+    container, stdout = record(name: 'roundtrip', marking: true)
+
+    assert_includes stdout, 'sent=true received=true covered=true',
+                    "the recorder refused a marker it should have accepted\n#{stdout}"
+
+    markers = ct_print_markers(container)
+    assert_equal 2, markers.length,
+                 "expected the send and the recv marker, got #{markers.inspect}"
+
+    send_marker, recv_marker = markers
+
+    # The hoisted top-level fields: what a consumer selects on without having
+    # to parse the metadata slot itself.
+    assert_equal BOUNDARY, send_marker['boundary_id']
+    assert_equal 'send', send_marker['direction']
+    assert_equal KEY, send_marker['key_value']
+    assert_equal BOUNDARY, recv_marker['boundary_id']
+    assert_equal 'recv', recv_marker['direction']
+    assert_equal KEY, recv_marker['key_value']
+
+    # ... and the full payload underneath them, which is what the debugger
+    # renders and what a cross-process chain walks.
+    payload = send_marker['correlation_marker']
+    refute_nil payload, "the marker payload did not decode: #{send_marker.inspect}"
+    assert_equal BOUNDARY, payload['boundary_id']
+    assert_equal 'send', payload['direction']
+    assert_equal KEY, payload['key_value']
+    assert_equal SHOW, payload['show_value']
+    assert_equal DESCRIPTION, payload['description']
+
+    # `show_text` is the NAME the shown value was read under. The send marker
+    # passed none and takes the library's default; the recv marker passed
+    # `envelope` and must keep it — a chain resuming its walk in the sending
+    # recording looks the value up by that name.
+    assert_equal 'show', payload['show_text']
+    assert_equal 'envelope', recv_marker['correlation_marker']['show_text'],
+                 'show_text was dropped, so a cross-process origin chain would ' \
+                 'reach this marker with its history unreachable'
+
+    # Both markers name a real step in this very container: the marker attaches
+    # to the enclosing step rather than floating free.
+    steps = step_count(container)
+    markers.each do |marker|
+      assert_operator marker['step_id'], :>=, 0
+      assert_operator marker['step_id'], :<, steps,
+                      "marker step_id #{marker['step_id']} is outside the container's " \
+                      "#{steps} steps, so it is not a usable coordinate"
+    end
+  end
+
+  # §11a.6 — a marker attaches to the enclosing step and mints none of its own.
+  def test_a_marker_mints_no_step
+    marked_container, = record(name: 'steps-marked', marking: true)
+    unmarked_container, = record(name: 'steps-unmarked', marking: false)
+
+    # The comparison is only worth anything if the two runs really did differ in
+    # the one respect under test.
+    assert_equal 2, ct_print_markers(marked_container).length
+    assert_empty ct_print_markers(unmarked_container),
+                 'the unmarked run wrote markers, so the step comparison below ' \
+                 'would compare two identical recordings and pass vacuously'
+
+    assert_equal step_count(unmarked_container), step_count(marked_container),
+                 'declaring a correlation marker changed the number of steps. A marker ' \
+                 'must attach to the enclosing step: minting one inserts an exec-stream ' \
+                 'event no user code executed and shifts every later step index, which is ' \
+                 "what spans' start_step/end_step are measured in."
+  end
+
+  # The whole API is a no-op — not an error — outside a recording.
+  #
+  # Run with plain `ruby`, no recorder anywhere: user code calls these
+  # unconditionally and is only sometimes recorded, so an exception (or a
+  # failure to even load the facade) would make the API unusable in production.
+  def test_the_api_is_a_no_op_when_not_recording
+    dir = Dir.mktmpdir('codetracer-markers-norecording-')
+    @tmp_dirs << dir
+    program = File.join(dir, 'marked.rb')
+    File.write(program, MARKER_PROGRAM)
+
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', GEM_LIB, program)
+
+    assert_predicate status, :success?,
+                     "the program failed when it was not being recorded:\n#{stdout}\n#{stderr}"
+    assert_includes stdout, COMPLETION_MARKER, "#{stdout}\n#{stderr}"
+    assert_includes stdout, 'sent=false received=false covered=false rejected=false',
+                    "the marker API must report `false` (nothing was recorded) rather " \
+                    "than claim success when no recording is active\n#{stdout}"
+  end
+
+  # `mark_span_coverage` really reaches the shared library's hex validation.
+  #
+  # Without this the `covered=true` above could be produced by a binding that
+  # accepted anything, and the resulting index would be keyed on bytes no
+  # consumer ever computes — present, correct-looking and permanently
+  # unqueryable.
+  def test_span_coverage_rejects_ids_that_are_not_wire_hex
+    _, stdout = record(name: 'coverage', marking: true)
+
+    assert_includes stdout, 'covered=true rejected=false',
+                    "a valid (trace_id, span_id) pair must be accepted and a malformed " \
+                    "one refused; got:\n#{stdout}"
+  end
+end

--- a/test/test_recorder_never_wedges.rb
+++ b/test/test_recorder_never_wedges.rb
@@ -35,6 +35,16 @@
 # * `2 ** 70` — `rb_num2long`'s `RangeError`, the one instance of this class
 #   that was already fixed; kept here so it stays fixed and is covered by the
 #   same harness as the rest.
+# * a correlation marker whose `key:` is an object with an exploding `to_s`,
+#   and one whose key is a String containing a NUL byte — the two shapes above,
+#   reached through an entry point the traced program calls DIRECTLY rather
+#   than through the event hook.
+#
+# **The rule this file states, and which the last two cases exist to honour:
+# every new entry point that touches a Ruby value needs a case here.** An entry
+# point called from user code is if anything more exposed than the hook: the
+# values are chosen by the program, and the hook's own `in_event_hook` guard has
+# to be armed and restored by hand on every path rather than by one caller.
 #
 # ## No mocks
 #
@@ -321,5 +331,108 @@ class RecorderNeverWedgesTest < Minitest::Test
     events = assert_records_without_wedging(source, name: 'bignum', expect_locals: ['big'])
     assert_includes events.to_s, (2**70).to_s,
                     'the out-of-word Integer should still be visible as its decimal text'
+  end
+
+  # A correlation marker whose boundary label and key are objects whose `to_s`
+  # raises.
+  #
+  # `CodeTracer::Native.mark_correlation_send` is called BY THE TRACED PROGRAM,
+  # so `key:` is an arbitrary object and rendering it is arbitrary user code.
+  # Two things have to hold, and only the first is about hanging:
+  #
+  # 1. The raise must not escape into the writer lock (the wedge), and it must
+  #    not escape into the traced program either — a program must not die
+  #    because it annotated itself while being recorded.
+  # 2. The marker must still be WRITTEN, with an empty key. A marker that was
+  #    silently dropped would look exactly like one that was never declared,
+  #    which is the invisible-failure mode the marker contract exists to
+  #    eliminate.
+  def test_correlation_marker_with_an_exploding_to_s_does_not_wedge
+    source = <<~RUBY
+      class ExplodingKey
+        def to_s
+          raise 'to_s exploded'
+        end
+      end
+
+      def probe
+        key = ExplodingKey.new
+        CodeTracer::Native.mark_correlation_send(ExplodingKey.new, key: key,
+                                                 show: ExplodingKey.new)
+      end
+
+      recorded = probe
+      puts "MARKER-RECORDED \#{recorded}"
+      puts '#{COMPLETION_MARKER}'
+    RUBY
+    recording = record(source, name: 'marker_to_s')
+    assert_marker_survived(recording, name: 'marker_to_s')
+
+    markers = ct_print_markers(single_container(recording))
+    assert_equal 1, markers.length,
+                 'the marker was dropped instead of being recorded with an unreadable key, ' \
+                 'so it is indistinguishable from one that was never declared'
+    assert_equal '', markers.first['key_value'],
+                 'an unrenderable key must come through as empty, not as some guess'
+    assert_equal 'send', markers.first['direction']
+  end
+
+  # A correlation-marker key that is a String containing a literal NUL byte.
+  #
+  # This is the `rb_string_value_cstr` shape (`ArgumentError` on an embedded
+  # NUL) at a NEW entry point.  It is the specific hazard
+  # `CTFS-Correlation-Marker-Contract.md` §11a.5 names — the reason the shared
+  # library's marker entry points take pointer + length instead of a
+  # NUL-terminated string, so the byte survives into the payload rather than
+  # truncating the key or raising on the way there.
+  def test_correlation_marker_with_a_nul_in_the_key_does_not_wedge
+    source = <<~'RUBY'
+      def probe
+        CodeTracer::Native.mark_correlation_recv('queue', key: "bad\0key",
+                                                 show: "bad\0body")
+      end
+
+      recorded = probe
+      puts "MARKER-RECORDED #{recorded}"
+      puts 'PROGRAM-COMPLETED'
+    RUBY
+    recording = record(source, name: 'marker_nul_key')
+    assert_marker_survived(recording, name: 'marker_nul_key')
+
+    markers = ct_print_markers(single_container(recording))
+    assert_equal 1, markers.length, 'the NUL-containing marker was dropped'
+    assert_equal "bad\0key", markers.first['key_value'],
+                 'the key was truncated at the NUL byte instead of being carried whole'
+    assert_equal 'queue', markers.first['boundary_id']
+    assert_equal 'recv', markers.first['direction']
+  end
+
+  private
+
+  # The wedge assertions shared by the two marker cases.
+  #
+  # Deliberately NOT `assert_records_without_wedging`: that helper asserts the
+  # trace has steps and named locals, which is about the event hook. What
+  # matters here is that the recorder survived, the program survived, and the
+  # marker call reported success rather than an exception.
+  def assert_marker_survived(recording, name:)
+    refute recording.timed_out,
+           "recording #{name} did not finish within #{RECORD_TIMEOUT_SECONDS}s — the recorder " \
+           "wedged (a Ruby exception raised inside a marker entry point stranded the tracer " \
+           "lock).\nRecorder output so far:\n#{recording.output}"
+    assert_predicate recording.status, :success?,
+                     "recorder exited with #{recording.status.inspect}\n#{recording.output}"
+    assert_includes recording.output, COMPLETION_MARKER,
+                    "the traced program did not run to completion — the exception raised " \
+                    "inside the recorder escaped into the program\n#{recording.output}"
+    assert_includes recording.output, 'MARKER-RECORDED true',
+                    "the marker entry point reported failure\n#{recording.output}"
+  end
+
+  # The single `.ct` container a recording produced.
+  def single_container(recording)
+    containers = Dir.glob(File.join(recording.out_dir, '*.ct'))
+    refute_empty containers, "no .ct container was written\n#{recording.output}"
+    containers.first
   end
 end


### PR DESCRIPTION
A recorded program can now say that a value left or entered it at a process
boundary, and that a recording covers a given distributed-trace span. Both go
through the shared CTFS writer, so this recorder marshals arguments and does
not build the on-disk document.

`CodeTracer::Native.mark_correlation_send` / `_recv` and `mark_span_coverage`
return false when nothing is being recorded, because user code calls them
unconditionally.

The entry points follow the shape this recorder's existing wedge regressions
forced: the re-entrancy guard is armed before any Ruby value is touched and
restored on every path, every value is converted to a Rust string before the
tracer lock is taken, and nothing raises until the guard is released. Strings
are passed as pointer and length, never as C strings — a Ruby string may
legally contain a NUL byte.

## Tests

- `test/test_recorder_never_wedges.rb` gains cases for the new entry points,
  including an object whose `to_s` raises and a key containing a literal NUL.
  Any entry point that touches Ruby values needs a case there; that is the
  file's stated rule.
- `test/test_correlation_markers.rb` records a real program and decodes it
  through `ct print`, asserting the marker's boundary, direction, key and the
  binding name of its shown value, that a marker adds no step, and that the
  API is inert when not recording.

`codetracer-pure-ruby-recorder` is untouched: it is the cross-validation
oracle and its AGENTS.md forbids substituting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)