### PR TITLE
ci: clone codetracer-launcher at dev, the branch it actually has

### DIFF
--- a/.github/workflows/launcher-integration.yml
+++ b/.github/workflows/launcher-integration.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-launcher
-          ref: main
+          ref: dev
           path: codetracer-launcher
           gh-token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Problem

The `launcher-integration` workflow cloned `metacraft-labs/codetracer-launcher` at `ref: main`. **That repo has no `main` branch.** Its branches are `dev` (the mainline, and its declared `defaultBranch` in the org governance config), `blocktracer`, `codetracer-test`, `fix/ci-trigger-default-branch`, `lnch-sizecap`.

`clone-repo`'s `ref` input has no default, so this value was explicit rather than inherited — it could never have resolved.

Live failure (from the sibling ruby recorder, identical code path, run [34490707591](https://github.com/metacraft-labs/codetracer-ruby-recorder/actions/runs/34490707591)):

```
Cloning metacraft-labs/codetracer-launcher at ref: main
##[error]checkout of revision main failed for metacraft-labs/codetracer-launcher (git exit 1).
error: pathspec 'main' did not match any file(s) known to git
##[error]Process completed with exit code 1.
```

The job dies ~1 second into the clone step, so the bundling smoke-test has never actually run.

## Fix

`ref: main` → `ref: dev`. One line.

## Note on the convention

`codetracer-launcher` already codifies this as a test — `tests/test_workflow_push_triggers.py` defines `DEAD_BRANCHES = {"main", "stable"}` and asserts `test_no_workflow_checks_a_sibling_repo_out_at_main()`. That test only scans the launcher's *own* `.github/workflows/`, which is why these sibling-repo references survived it.

This change does **not** touch any `uses:` action reference.